### PR TITLE
refactor(transfer): update css class name

### DIFF
--- a/style/web/components/transfer/_index.less
+++ b/style/web/components/transfer/_index.less
@@ -15,7 +15,7 @@
   color: @transfer-font-color;
   max-height: 100%;
 
-  &-list {
+  &__list {
     position: relative;
     display: inline-block;
     min-width: @transfer-common-width;
@@ -31,7 +31,7 @@
       border-radius: @transfer-border-radius;
     }
 
-    &__header {
+    &-header {
       position: absolute;
       display: flex;
       justify-content: space-between;
@@ -42,7 +42,7 @@
       padding: @transfer-list-header-padding;
       margin: @transfer-list-header-margin;
 
-      & + :not(.@{prefix}-transfer-list-with-search) {
+      & + :not(.@{prefix}-transfer__list--with-search) {
         border-top: @transfer-border;
       }
 
@@ -67,25 +67,18 @@
       }
     }
 
-    &__body {
+    &-body {
       position: relative;
       height: 100%;
       padding: @transfer-list-body-padding;
     }
 
-    &-with-search {
+    &--with-search {
       padding-top: @transfer-list-with-search-padding-top;
       border-top: @transfer-list-with-search-border;
     }
 
-    &-search-wrapper {
-      position: absolute;
-      top: 0;
-      width: 100%;
-      padding: @transfer-list-search-wrapper-margin;
-    }
-
-    &__content {
+    &-content {
       height: 100%;
       width: 100%;
       overflow: auto;
@@ -113,7 +106,7 @@
       }
     }
 
-    &__item {
+    &-item {
       padding: @transfer-list-item-padding;
       display: flex;
       cursor: pointer;
@@ -132,16 +125,16 @@
       }
     }
 
-    &__item:hover {
+    &-item:hover {
       background: @transfer-bg-hover;
       transition: background-color @anim-duration-base @anim-time-fn-easing;
     }
 
-    &__item.@{prefix}-is-checked {
+    &-item.@{prefix}-is-checked {
       background: @transfer-bg-checked;
     }
 
-    &__wrapper {
+    &-wrapper {
       position: relative;
       height: 100%;
       width: 100%;
@@ -149,14 +142,14 @@
       padding: @transfer-list-wrapper-padding;
     }
 
-    &__pagination {
+    &-pagination {
       height: @transfer-list-pagination-height;
       vertical-align: middle;
       padding: @transfer-list-pagination-padding;
       line-height: @transfer-list-pagination-line-height;
     }
 
-    &__footer {
+    &-footer {
       position: absolute;
       left: 0;
       bottom: 0;
@@ -165,7 +158,7 @@
     }
   }
 
-  &-operations {
+  &__operations {
     display: inline-flex;
     flex-direction: column;
     margin: @transfer-operations-margin;
@@ -197,7 +190,7 @@
     }
   }
 
-  &-empty {
+  &__empty {
     text-align: center;
     position: absolute;
     color: @text-color-placeholder;
@@ -205,81 +198,88 @@
     left: 50%;
     transform: translate(-50%, -50%);
   }
+
+  &__search-wrapper {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    padding: @transfer-list-search-wrapper-margin;
+  }
 }
 
 // 只有search时候的高度
-.@{prefix}-transfer-search {
+.@{prefix}-transfer__search {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: @transfer-with-search-height;
   }
 }
 
 // 与Tree组件结合使用时的高度
-.@{prefix}-transfer-with-tree {
+.@{prefix}-transfer--with-tree {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: auto;
   }
 }
 
 // 只有翻页时候的高度
-.@{prefix}-transfer-pagination {
+.@{prefix}-transfer__pagination {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: @transfer-with-pagination-height;
     padding-bottom: @transfer-with-pagination-padding-bottom;
   }
 }
 
 // 只有footer时候的高度
-.@{prefix}-transfer-footer {
+.@{prefix}-transfer__footer {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: @transfer-with-footer-height;
     padding-bottom: @transfer-with-footer-padding-bottom;
   }
 }
 
 // 同时有翻页和footer时候的高度
-.@{prefix}-transfer-pagination.@{prefix}-transfer-footer {
+.@{prefix}-transfer__pagination.@{prefix}-transfer__footer {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: @transfer-with-footer-both-height;
     padding-bottom: @transfer-with-pagination-footer-padding-bottom;
   }
 }
 
 // 同时有search和footer时候的高度
-.@{prefix}-transfer-search.@{prefix}-transfer-footer {
+.@{prefix}-transfer__search.@{prefix}-transfer__footer {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: @transfer-with-footer-both-height;
     padding-bottom: @transfer-with-search-footer-padding-bottom;
   }
 }
 
 // 同时有search和pagination时候的高度
-.@{prefix}-transfer-search.@{prefix}-transfer-pagination {
+.@{prefix}-transfer__search.@{prefix}-transfer__pagination {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: @transfer-with-both-height;
     padding-bottom: @transfer-with-search-pagination-padding-bottom;
   }
 }
 
 // 同时有search和pagination和footer
-.@{prefix}-transfer-search.@{prefix}-transfer-footer.@{prefix}-transfer-pagination {
+.@{prefix}-transfer__search.@{prefix}-transfer__footer.@{prefix}-transfer__pagination {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: @transfer-with-all-height;
     padding-bottom: @transfer-with-all-padding-bottom;
   }
 }
 
-.@{prefix}-transfer-wrapper {
+.@{prefix}-transfer__wrapper {
 
-  .@{prefix}-transfer-list {
+  .@{prefix}-transfer__list {
     height: @transfer-wrap-height;
     width: @transfer-wrap-width;
     overflow: scroll;

--- a/style/web/components/transfer/index.html
+++ b/style/web/components/transfer/index.html
@@ -29,8 +29,8 @@
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
         <div class="t-transfer">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
              <div>
                <label class="t-checkbox">
                  <input type="checkbox" class="t-checkbox__former" value="">
@@ -39,31 +39,31 @@
                <span>4项</span>
              </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -74,14 +74,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -90,8 +90,8 @@
                 <span>0项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-empty">暂无数据</div>
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__empty">暂无数据</div>
             </div>
           </div>
         </div>
@@ -104,9 +104,9 @@
     <h2 class="tdesign-demo-item__title">1.1.2 带搜索框</h2>
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
-        <div class="t-transfer t-transfer-search">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+        <div class="t-transfer t-transfer__search">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -115,8 +115,8 @@
                 <span>4项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body t-transfer-list-with-search">
-              <div class="t-transfer-list-search-wrapper">
+            <div class="t-transfer__list-body t-transfer__list--with-search">
+              <div class="t-transfer__search-wrapper">
                 <div class="t-input t-input--prefix t-input--suffix">
                   <input type="text" class="t-input__inner">
                   <span class="t-input__suffix">
@@ -124,30 +124,30 @@
                  </span>
                 </div>
               </div>
-              <div class="t-transfer-list__content">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -158,14 +158,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -174,8 +174,8 @@
                 <span>0项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body  t-transfer-list-with-search">
-              <div class="t-transfer-list-search-wrapper">
+            <div class="t-transfer__list-body  t-transfer__list--with-search">
+              <div class="t-transfer__search-wrapper">
                 <div class="t-input t-input--prefix t-input--suffix">
                   <input type="text" class="t-input__inner">
                   <span class="t-input__suffix">
@@ -183,7 +183,7 @@
                  </span>
                 </div>
               </div>
-              <div class="t-transfer-empty">暂无数据</div>
+              <div class="t-transfer__empty">暂无数据</div>
             </div>
           </div>
         </div>
@@ -196,9 +196,9 @@
     <h2 class="tdesign-demo-item__title">1.1.3 结合树结构</h2>
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
-        <div class="t-transfer t-transfer-wrapper">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+        <div class="t-transfer t-transfer__wrapper">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -207,8 +207,8 @@
                 <span>4项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__wrapper">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-wrapper">
                 <div class="t-tree">
                   <!-- 第0层 -->
                   <div class="t-tree__item">
@@ -314,14 +314,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -330,9 +330,9 @@
                 <span>0项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__wrapper">
-                <div class="t-transfer-empty">暂无数据</div>
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-wrapper">
+                <div class="t-transfer__empty">暂无数据</div>
               </div>
             </div>
           </div>
@@ -347,8 +347,8 @@
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
         <div class="t-transfer">
-          <div class="t-transfer-list t-transfer-list-source" style="width: 300px; height: 280px;">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-source" style="width: 300px; height: 280px;">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -357,31 +357,31 @@
                 <span>4项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -392,14 +392,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target" style="width: 300px; height: 280px">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target" style="width: 300px; height: 280px">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -408,8 +408,8 @@
                 <span>0项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-empty">暂无数据</div>
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__empty">暂无数据</div>
             </div>
           </div>
         </div>
@@ -423,8 +423,8 @@
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
         <div class="t-transfer">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
              <div>
                <label class="t-checkbox t-is-indeterminate">
                  <input type="checkbox" class="t-checkbox__former" value="">
@@ -433,31 +433,31 @@
                <span>4项</span>
              </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox t-is-checked">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox t-is-checked">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -468,14 +468,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--primary t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
              <div>
                <label class="t-checkbox">
                  <input type="checkbox" class="t-checkbox__former" value="">
@@ -484,8 +484,8 @@
                <span>0项</span>
              </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-empty">暂无数据</div>
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__empty">暂无数据</div>
             </div>
           </div>
         </div>
@@ -499,8 +499,8 @@
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
         <div class="t-transfer">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -509,31 +509,31 @@
                 <span>4项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -544,14 +544,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--primary t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox t-is-indeterminate">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -560,31 +560,31 @@
                 <span>4项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 5</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox t-is-checked">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 6</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox t-is-checked">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 7</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -606,8 +606,8 @@
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
         <div class="t-transfer">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
              <div>
                <label class="t-checkbox t-is-indeterminate">
                  <input type="checkbox" class="t-checkbox__former" value="">
@@ -616,31 +616,31 @@
                <span>4项</span>
              </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox t-is-checked">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox t-is-checked t-is-disabled">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox t-is-checked t-is-disabled">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -651,14 +651,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--primary t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
              <div>
                <label class="t-checkbox">
                  <input type="checkbox" class="t-checkbox__former" value="">
@@ -667,17 +667,17 @@
                <span>2项</span>
              </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -699,8 +699,8 @@
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
         <div class="t-transfer">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
              <div>
                <label class="t-checkbox">
                  <input type="checkbox" class="t-checkbox__former" value="">
@@ -709,24 +709,24 @@
                <span>3项</span>
              </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>第一段信息第一段信息第一段信息</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>第二段信息第二段信息第二段信息</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -737,14 +737,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -753,8 +753,8 @@
                 <span>0项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-empty">暂无数据</div>
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__empty">暂无数据</div>
             </div>
           </div>
         </div>
@@ -767,9 +767,9 @@
     <h2 class="tdesign-demo-item__title">1.3.5 数据项数量过多时</h2>
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
-        <div class="t-transfer t-transfer-pagination">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+        <div class="t-transfer t-transfer__pagination">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -778,31 +778,31 @@
                 <span>12项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -812,20 +812,20 @@
                 </div>
               </div>
             </div>
-            <div class="t-transfer-list__pagination">
+            <div class="t-transfer__list-pagination">
               <i class="t-icon t-icon-arrow-left"></i>
               <span>1/3</span>
               <i class="t-icon t-icon-arrow-right"></i>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -834,31 +834,31 @@
                 <span>400项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 5</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 6</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 7</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -868,7 +868,7 @@
                 </div>
               </div>
             </div>
-            <div class="t-transfer-list__pagination">
+            <div class="t-transfer__list-pagination">
               <i class="t-icon t-icon-arrow-left"></i>
               <span>1/100</span>
               <i class="t-icon t-icon-arrow-right"></i>
@@ -885,8 +885,8 @@
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
         <div class="t-transfer">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -896,31 +896,31 @@
               </div>
               <span>源列表</span>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -931,14 +931,14 @@
               </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -948,8 +948,8 @@
               </div>
               <span>目标列表</span>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-empty">暂无数据</div>
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__empty">暂无数据</div>
             </div>
           </div>
         </div>
@@ -962,9 +962,9 @@
     <h2 class="tdesign-demo-item__title">1.3.7 自定义底部</h2>
     <div class="tdesign-demo-item__body">
       <div class="tdesign-demo-block">
-        <div class="t-transfer t-transfer-footer">
-          <div class="t-transfer-list t-transfer-list-source">
-            <div class="t-transfer-list__header">
+        <div class="t-transfer t-transfer__footer">
+          <div class="t-transfer__list t-transfer__list-source">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -973,31 +973,31 @@
                 <span>4项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-list__content">
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__list-content">
                 <div class="t-checkbox-group">
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 1</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 2</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
                     </label>
                     <span>content 3</span>
                   </li>
-                  <li class="t-transfer-list__item">
+                  <li class="t-transfer__list-item">
                     <label class="t-checkbox">
                       <input type="checkbox" class="t-checkbox__former" value="">
                       <span class="t-checkbox__input"></span>
@@ -1007,20 +1007,20 @@
                 </div>
               </div>
             </div>
-            <div class="t-transfer-list__footer">
+            <div class="t-transfer__list-footer">
              <div style="width: 100%; text-align: right">
                <button class="t-button t-button--primary" style="height: 24px;margin: 12px 12px 12px auto">自定义功能</button>
              </div>
             </div>
           </div>
-          <div class="t-transfer-operations">
+          <div class="t-transfer__operations">
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"
             ><i class="t-icon t-icon-arrow-right"></i></button>
             <button class="t-button t-button--line t-is-disabled t-button--icon-only"><i
               class="t-icon t-icon-arrow-left"></i></button>
           </div>
-          <div class="t-transfer-list t-transfer-list-target">
-            <div class="t-transfer-list__header">
+          <div class="t-transfer__list t-transfer__list-target">
+            <div class="t-transfer__list-header">
               <div>
                 <label class="t-checkbox">
                   <input type="checkbox" class="t-checkbox__former" value="">
@@ -1029,10 +1029,10 @@
                 <span>0项</span>
               </div>
             </div>
-            <div class="t-transfer-list__body">
-              <div class="t-transfer-empty">暂无数据</div>
+            <div class="t-transfer__list-body">
+              <div class="t-transfer__empty">暂无数据</div>
             </div>
-            <div class="t-transfer-list__footer">
+            <div class="t-transfer__list-footer">
               <div style="width: 100%; text-align: right">
                 <button class="t-button t-button--primary" style="height: 24px;margin: 12px 12px 12px auto">自定义功能</button>
               </div>


### PR DESCRIPTION
规范CSS类名，具体修改如下：

Component | old class name | new class name
-- | -- | --
Transfer | t-transfer-list-source | t-transfer__list-source
Transfer | t-transfer-list-target | t-transfer__list-target
Transfer | t-transfer-list__header | t-transfer__list-header
Transfer | t-transfer-list__body | t-transfer__list-body
Transfer | t-transfer-list-with-search | t-transfer__list--with-search
Transfer | t-transfer-list-search-wrapper | t-transfer__search-wrapper
Transfer | t-transfer-list__content | t-transfer__list-content
Transfer | t-transfer-list__item | t-transfer__list-item
Transfer | t-transfer-list__wrapper | t-transfer__list-wrapper
Transfer | t-transfer-list__pagination | t-transfer__list-pagination
Transfer | t-transfer-list__footer | t-transfer__list-footer
Transfer | t-transfer-operations | t-transfer__operations
Transfer | t-transfer-search | t-transfer__search
Transfer | t-transfer-with-tree | t-transfer--with-tree
Transfer | t-transfer-pagination | t-transfer__pagination
Transfer | t-transfer-footer | t-transfer__footer
Transfer | t-transfer-wrapper | t-transfer__wrapper
Transfer | t-transfer-empty | t-transfer__empty
