### PR TITLE
fix(web/menu): remove useless code

### DIFF
--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -277,7 +277,7 @@ a.@{prefix}-menu__item {
       }
 
       &.@{prefix}-menu__item--plain::after {
-        content: "1";
+        content: "";
       }
 
       span {


### PR DESCRIPTION
删除`web/menu`中无用代码。该代码会导致`menu`组件在收起时出现无用信息。[refer](https://tdesign.tencent.com/react/components/menu#%E5%8F%AF%E5%88%86%E7%BB%84%E7%9A%84%E4%BE%A7%E8%BE%B9%E5%AF%BC%E8%88%AA)
如下图所示：
![image](https://user-images.githubusercontent.com/32590310/147303890-ab2e2da6-0a92-437f-8ee7-d6fb08df2a8e.png)
