### PR TITLE
fix(web/slider): fix inputNumber style when slider use inputNumber wi…

### DIFF
--- a/style/web/components/slider/_index.less
+++ b/style/web/components/slider/_index.less
@@ -25,6 +25,9 @@
 
   .@{prefix}-input-number {
     width: @slider-input-width;
+    &.@{prefix}-input-number--row {
+      width: @slider-row-input-width;
+    }
   }
 }
 

--- a/style/web/components/slider/_var.less
+++ b/style/web/components/slider/_var.less
@@ -16,6 +16,7 @@
 
 // 尺寸
 @slider-input-width: 80px;
+@slider-row-input-width: 120px;
 @slider-height: 18px;
 @slider-rail-track-step-size: 4px;
 @slider-control-bar-size: 16px;


### PR DESCRIPTION
修复`web/slider`在`inputNumber`使用`theme: row`时样式错误问题。
默认固定的`width: 80px`导致无法撑开。[refer](https://tdesign.tencent.com/react/components/slider#%E6%95%B0%E5%AD%97%E8%BE%93%E5%85%A5%E6%A1%86)
如下图所示：
![image](https://user-images.githubusercontent.com/32590310/147307771-718f2ec7-fbf5-43fe-9770-8f1199e8564c.png)
