### PR TITLE
fix: table ellipsis style bug fix

### DIFF
--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -308,7 +308,6 @@
     th,
     td {
       overflow-wrap: break-word;
-      white-space: nowrap;
     }
 
     .@{prefix}-table__header {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35833812/147633946-576a5dce-128e-4ec7-b5fe-e877928a85bf.png)

修复 ellipsis  = false 时的截断问题