### PR TITLE
feat: move css vars to index

### DIFF
--- a/style/web/base.less
+++ b/style/web/base.less
@@ -5,7 +5,3 @@
 // 组件直接在tsx/sfc中引用的样式
 
 @import "./_global.less";
-
-// theme(用于换肤)
-
-@import "./theme/_index.less";

--- a/style/web/index.less
+++ b/style/web/index.less
@@ -5,3 +5,6 @@
 // components
 
 @import "./components/_index.less";
+
+// theme(用于换肤)
+@import "./theme/_index.less";


### PR DESCRIPTION
# 现状
由于在每个组件目录下都引入了 `theme/_index`（css 变量文件），以 button 组件为例：

https://github.com/Tencent/tdesign-vue/blob/develop/src/button/style/index.js
https://github.com/Tencent/tdesign-common/blob/develop/style/web/components/button/_index.less#L1
https://github.com/Tencent/tdesign-common/blob/develop/style/web/base.less#L11

引入链路为：`button/_index.less` -> `/base.less` -> `theme/_index.less`

es 中产物：
![image](https://user-images.githubusercontent.com/7600149/147737441-5f2e3d63-a9bf-487e-95a9-f13a8aca2102.png)


## 存在的问题

在使用组件库 npm 包中 `es` 或 `esm` 目录下构建产物时，无论是全量引入还是按需引入方式，都会重复引入多次该文件，比如在 tdesign-vue-starter 中使用时页面大量重复声明了所有 css vars：

![image](https://user-images.githubusercontent.com/7600149/147736946-f34480c8-bc65-4ef1-8375-70f66058de6c.png)

访问线上体验：https://tdesign.tencent.com/starter/vue/#/dashboard/base

# 修改后
每个组件中不再单独引入 `theme/_index.less` 中的变量，改为在 `src/style/index` 中引入一次，es 中单个组件中不包括变量声明：
![image](https://user-images.githubusercontent.com/7600149/147737561-8f138698-1c5a-45b8-8018-ea9d8de362bc.png)

只在 `es/style/index.css` 文件中声明一次：
![image](https://user-images.githubusercontent.com/7600149/147737658-69dc439e-a53b-4e73-b8ee-838932a00cdf.png)

## 可能存在的问题
需要跟所有使用者强调，无论全量/按需引入，都必须引入 `es/style/index.css`，
![image](https://user-images.githubusercontent.com/7600149/147737777-53fbe0ea-f93e-4f5d-ac3a-54886741baa8.png)
