### PR TITLE
perf: adjust popup animation time fn

### DIFF
--- a/style/web/_variables.less
+++ b/style/web/_variables.less
@@ -260,7 +260,7 @@
 
 // 动画
 @anim-time-fn-easing: cubic-bezier(.38, 0, .24, 1);
-@anim-time-fn-ease-out: cubic-bezier(0, 0, .15, 1);
+@anim-time-fn-ease-out: cubic-bezier(0, 0, .32, 1);
 @anim-time-fn-ease-in: cubic-bezier(.82, 0, 1, .9);
 @anim-duration-base: .2s;
 @anim-duration-moderate: .24s;

--- a/style/web/components/popup/_index.less
+++ b/style/web/components/popup/_index.less
@@ -69,10 +69,10 @@
   }
 }
 
-.arrow-placment-top();
-.arrow-placment-bottom();
-.arrow-placment-left();
-.arrow-placment-right();
+.arrow-placement-top();
+.arrow-placement-bottom();
+.arrow-placement-left();
+.arrow-placement-right();
 
 // animation
 .@{popup-flow}-enter,
@@ -93,9 +93,9 @@
 }
 
 .@{popup-flow}-enter-active {
-  transition: @popup-flow-transition;
+  transition: @popup-flow-transition-enter;
 }
 
 .@{popup-flow}-leave-active {
-  transition: @popup-flow-transition;
+  transition: @popup-flow-transition-leave;
 }

--- a/style/web/components/popup/_mixin.less
+++ b/style/web/components/popup/_mixin.less
@@ -1,4 +1,4 @@
-.arrow-placment-top {
+.arrow-placement-top {
 
   .@{prefix}-popup[data-popper-placement^="top"] .@{prefix}-popup__arrow {
     bottom: calc(-@popup-arrow-width / 2);
@@ -23,7 +23,7 @@
   }
 }
 
-.arrow-placment-bottom {
+.arrow-placement-bottom {
 
   .@{prefix}-popup[data-popper-placement^="bottom"] .@{prefix}-popup__arrow {
     top: calc(-@popup-arrow-width / 2);
@@ -48,7 +48,7 @@
   }
 }
 
-.arrow-placment-left {
+.arrow-placement-left {
 
   .@{prefix}-popup[data-popper-placement^="left"] .@{prefix}-popup__arrow {
     right: calc(-@popup-arrow-width / 2);
@@ -72,7 +72,7 @@
   }
 }
 
-.arrow-placment-right {
+.arrow-placement-right {
 
   .@{prefix}-popup[data-popper-placement^="right"] .@{prefix}-popup__arrow {
     left: calc(-@popup-arrow-width / 2);

--- a/style/web/components/popup/_var.less
+++ b/style/web/components/popup/_var.less
@@ -29,7 +29,6 @@
 @popup-flow-transition-enter: opacity @popup-flow-duration linear,
   visibility @popup-flow-duration @popup-flow-fn,
   max-height @popup-flow-duration @anim-time-fn-easing;
-  
 @popup-flow-transition-leave: opacity @popup-flow-duration @anim-time-fn-ease-out,
   visibility @popup-flow-duration @popup-flow-fn,
   max-height @popup-flow-duration @anim-time-fn-easing;

--- a/style/web/components/popup/_var.less
+++ b/style/web/components/popup/_var.less
@@ -26,6 +26,10 @@
 @popup-flow: t-popup--animation;
 @popup-flow-duration: @anim-duration-base;
 @popup-flow-fn: @anim-time-fn-ease-in;
-@popup-flow-transition: opacity @popup-flow-duration @popup-flow-fn,
+@popup-flow-transition-enter: opacity @popup-flow-duration linear,
+  visibility @popup-flow-duration @popup-flow-fn,
+  max-height @popup-flow-duration @anim-time-fn-easing;
+  
+@popup-flow-transition-leave: opacity @popup-flow-duration @anim-time-fn-ease-out,
   visibility @popup-flow-duration @popup-flow-fn,
   max-height @popup-flow-duration @anim-time-fn-easing;


### PR DESCRIPTION
## 主要改动：优化popup的transition动画

### 展开动画改动：

popup的动画实际上由透明度和高度动画组成，此前透明度入场动画曲线使用的是`cubic-bezier(.38, 0, .24, 1)`
效果可见 https://tdesign.tencent.com/design/motion 

![image](https://user-images.githubusercontent.com/26377630/148343469-1011d390-c857-46a3-a2d8-23209903095e.png)

将这个动画延长到2s 可以看到效果透明度变化在前段较缓后段加速的情况 
以`select`为例

![animation1](https://user-images.githubusercontent.com/26377630/148344009-dca58119-6e81-4ffe-954d-e6b879166289.gif)

以`tooltips`为例

![Jan-06-2022 15-18-24](https://user-images.githubusercontent.com/26377630/148344286-7c568d99-81cf-4b98-88f6-3cb190553632.gif)

由于曲线前段缓慢的透明度变化，导致了一定程度的视觉卡顿；
调整展开时间曲线为`linear`效果，线性时间曲线 同样延长至2s观察效果；

以`select`为例

![select](https://user-images.githubusercontent.com/26377630/148345052-54d72347-36f6-42f3-ab40-1889fa3fa638.gif)

以`tooltips`为例

![tooltip](https://user-images.githubusercontent.com/26377630/148345589-bee96561-ac70-440d-b980-51ba1d53c8aa.gif)

#### 调整后正常速度效果

以`select`为例

![select 2](https://user-images.githubusercontent.com/26377630/148345920-ef6e70ac-8b6a-4168-93be-efd5ee81d700.gif)

以`tooltips`为例

![tooltip 2](https://user-images.githubusercontent.com/26377630/148345925-cfd6c8fa-89a4-4caf-a5ec-b59fde87c764.gif)

### 收起动画改动：
收起动画此前存在的问题是收起阴影效果拖拉 时间曲线为`cubic-bezier(0.38, 0, 0.24, 1)`
将这个动画延长到2s 可以明显看到后半段box-shadow仍然较重

以`select`为例

![select collpase previous](https://user-images.githubusercontent.com/26377630/148347125-b5109c28-2295-46e4-a9a9-c772241548ff.gif)


调整时间曲线为`cubic-bezier(0,0,.32,1)` 同样将动画延长到2s看效果 

以`select`为例

![select collpase optimize](https://user-images.githubusercontent.com/26377630/148347619-141b2ac2-1dff-413d-87b2-b1306ccb26e5.gif)



#### 调整后正常速度效果

以`select`为例

![select collpase](https://user-images.githubusercontent.com/26377630/148346577-d5f8cc0a-7012-4f5d-a359-47ee76c49a51.gif)


### 其他
typo error fix. `placment`-> `placement`