### PR TITLE
fix(web/loading): fix loading style

### DIFF
--- a/style/web/components/loading/_index.less
+++ b/style/web/components/loading/_index.less
@@ -96,9 +96,9 @@
     background: conic-gradient(from 90deg at 50% 50%, #fff 0deg, currentColor 360deg);
     border-radius: 50%;
     /* stylelint-disable-next-line */
-    mask: radial-gradient(transparent calc(50% ~"-" .5px), #fff 50%);
+    mask: radial-gradient(transparent 50%, #fff 50%);
 
     /* stylelint-disable-next-line */
-    -webkit-mask: radial-gradient(transparent calc(50% ~"-" .5px), #fff 50%);
+    -webkit-mask: radial-gradient(transparent 50%, #fff 50%);
   }
 }


### PR DESCRIPTION
`web/loading`组件样式。

在高分辨率的显示器下，目前loading的样式带有明显的锯齿感，给人一种模糊不清晰的感觉。

### 现有样式：

![Kapture 2022-01-07 at 09 33 51](https://user-images.githubusercontent.com/32590310/148476766-258fe174-22af-4530-9e3f-308b893db08a.gif)

### 修改后样式效果：
![QQ20220107-093635-HD](https://user-images.githubusercontent.com/32590310/148477056-304857ec-6811-44fe-8b67-b778158f1d54.gif)

