### PR TITLE
fix: year picker style

### DIFF
--- a/style/web/components/date-picker/_index.less
+++ b/style/web/components/date-picker/_index.less
@@ -283,12 +283,6 @@
           margin-top: 16px;
         }
       }
-
-      &:last-child {
-        .@{prefix}-date-picker__cell {
-          text-align: left;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
remove useless style class.

before:
![image](https://user-images.githubusercontent.com/7600149/149135801-8a56b349-206c-46aa-a86c-910e6edd2a45.png)

after:
![image](https://user-images.githubusercontent.com/7600149/149135838-bfac7087-e301-49bb-99d4-ebd288234bfe.png)
