### PR TITLE
fix: textarea default background style

### DIFF
--- a/style/web/components/textarea/_index.less
+++ b/style/web/components/textarea/_index.less
@@ -18,6 +18,7 @@
       border: 1px solid @textarea-border-color;
       border-radius: @textarea-border-radius;
       padding: @textarea-padding;
+      background-color: @textarea-bg-color-default;
       font-family: PingFangSC-Regular;
       font-size: @textarea-font-size;
       color: @textarea-text-color;

--- a/style/web/components/textarea/_var.less
+++ b/style/web/components/textarea/_var.less
@@ -15,6 +15,7 @@
 @textarea-placeholder-color: @text-color-placeholder;
 @textarea-text-color: inherit;
 @textarea-limit-color: @text-color-placeholder;
+@textarea-bg-color-default: @bg-color-specialcomponent;
 @textarea-bg-color-disabled: @bg-color-component-disabled;
 @textarea-color-text-disabled: @text-color-disabled;
 


### PR DESCRIPTION
参照 Input 背景色实现，修复 https://github.com/Tencent/tdesign-vue/issues/257 问题