### PR TITLE
fix(table): 固定列单元格的z-index值设置为100

### DIFF
--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -386,7 +386,7 @@
 
     .@{prefix}-table__cell--fixed-left,
     .@{prefix}-table__cell--fixed-right {
-      z-index: 1;
+      z-index: 100;
     }
 
     .@{prefix}-table__cell--fixed-left-last {


### PR DESCRIPTION
before:

<img width="828" alt="wecom-temp-a15483262ebb61dfd39cc18c92f365be" src="https://user-images.githubusercontent.com/22365107/149889103-44b5fe5d-3d26-4a82-a6c8-d99bc6bc2924.png">


after:

<img width="801" alt="wecom-temp-a4c0de94a0f9b4d7387b7d64edef9a5a" src="https://user-images.githubusercontent.com/22365107/149889082-bd9e8075-25ad-490b-9262-58f7b5a5f401.png">
