### PR TITLE
feat: 修改日历组件右上角按钮组件的hover样式

### DIFF
--- a/style/web/components/calendar/_index.less
+++ b/style/web/components/calendar/_index.less
@@ -24,9 +24,9 @@
       }
     }
 
-    &:hover {
-      background-color: @calendar-bg;
-    }
+    // &:hover {
+    //   background-color: @calendar-bg;
+    // }
   }
 
   &--full {


### PR DESCRIPTION
日历右上角按钮组件hover后会消失，原因是重写了hover样式，现在去掉。