### PR TITLE
fix: remove logo font-size

### DIFF
--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -41,7 +41,6 @@ a.@{prefix}-menu__item {
 
   .@{prefix}-menu__logo:not(:empty) {
     height: 100%;
-    font-size: 0;
     margin-right: 32px;
   }
 


### PR DESCRIPTION
关联issue，https://github.com/Tencent/tdesign-vue-next/issues/289

因为 `font-size: 0` 导致显示为空。

https://codesandbox.io/s/tdesign-vue-next-demo-forked-lw1uq