### PR TITLE
fix: textarea default font color, #413

### DIFF
--- a/style/web/components/textarea/_var.less
+++ b/style/web/components/textarea/_var.less
@@ -15,7 +15,7 @@
 
 // 颜色
 @textarea-placeholder-color: @text-color-placeholder;
-@textarea-text-color: inherit;
+@textarea-text-color: @text-color-primary;
 @textarea-limit-color: @text-color-placeholder;
 @textarea-bg-color-default: @bg-color-specialcomponent;
 @textarea-bg-color-disabled: @bg-color-component-disabled;


### PR DESCRIPTION
https://github.com/Tencent/tdesign-vue/issues/413

textarea 设置的默认文字颜色是继承父级，有可能导致用户项目里设置了 font-color 的时候其他主题下展示有问题，改为跟 input 等输入框组件一致