### PR TITLE
fix: tag-input width

### DIFF
--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -23,13 +23,28 @@
   &:hover,
   .@{prefix}-input--focused {
     .@{prefix}-input__inner {
-      min-width: 60px;
+      min-width: 40px;
     }
   }
 
   .@{prefix}-tag-input__prefix,
   .@{prefix}-input__prefix:empty {
     margin-left: @spacer-s;
+  }
+
+  &.@{prefix}-input--auto-width {
+    padding-right: @spacer-s;
+    .@{prefix}-tag {
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+
+    &:hover,.@{prefix}-is-focused {
+      .@{prefix}-input__prefix:not(:empty) + .@{prefix}-input__inner {
+        margin-left: @spacer-s;
+      }
+    }
   }
 }
 
@@ -43,6 +58,7 @@
   &.@{prefix}-input {
     display: block;
     height: auto;
+    padding-right: 24px;
 
     &.t-input--prefix > .t-input__prefix {
       display: inline;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
**1. 修复 breakline 模式下的clearIcon样式重叠**

解决方案：增加 breakline 与 clearIcon 等宽的右侧padding

before

<img width="713" alt="image" src="https://user-images.githubusercontent.com/35833812/158150746-812ef18f-3c1c-448f-8d1a-4d38c8faddb7.png">

after
<img width="526" alt="image" src="https://user-images.githubusercontent.com/35833812/158151132-275776fc-08c7-435f-a818-ab9597d01866.png">


**2. 修复 autowidth 模式下的 padding 不对称**

解决方案：autowidth 模式下取消最后一个tag的margin-right。并且input__inner在hover状态下增加margin-left

before：
<img width="211" alt="image" src="https://user-images.githubusercontent.com/35833812/158150875-45e81f5d-d3e0-4257-949d-436cb6001517.png">

after:
<img width="704" alt="image" src="https://user-images.githubusercontent.com/35833812/158151006-a44de762-c14c-4826-8a0f-0a40ce12b26d.png">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tag-input): 修复 breakline 模式下的clearIcon样式重叠
- fix(tag-input): 修复 autowidth 模式下的 padding 不对称


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
