### PR TITLE
fix: 修复drawer 隐藏状态下不必要宽度占位问题

### DIFF
--- a/style/web/components/drawer/_index.less
+++ b/style/web/components/drawer/_index.less
@@ -13,6 +13,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
+  overflow: hidden;
 
   &--lock {
     overflow: hidden;


### PR DESCRIPTION
修复这个问题：
<img width="1168" alt="image" src="https://user-images.githubusercontent.com/24469546/159202709-4c792482-abe2-42a2-ba8b-ad9bd2b6b47c.png">
