### PR TITLE
fix: 修复checkbox inline-block 高度问题

### DIFF
--- a/style/web/components/checkbox/_index.less
+++ b/style/web/components/checkbox/_index.less
@@ -10,15 +10,8 @@
 
 // <name> 替换为组件名
 .@{checkbox-cls}-group {
-  display: inline-block;
-
-  .@{checkbox-cls} {
-    margin-right: @checkbox-group-margin;
-
-    &:last-child {
-      margin-right: 0;
-    }
-  }
+  display: inline-flex;
+  gap: @checkbox-group-gap;
 }
 
 .@{checkbox-cls} {

--- a/style/web/components/checkbox/_index.less
+++ b/style/web/components/checkbox/_index.less
@@ -11,6 +11,7 @@
 // <name> 替换为组件名
 .@{checkbox-cls}-group {
   display: inline-flex;
+  flex-wrap: wrap;
   gap: @checkbox-group-gap;
 }
 

--- a/style/web/components/checkbox/_var.less
+++ b/style/web/components/checkbox/_var.less
@@ -53,6 +53,6 @@
 @checkbox-input-label-spacer: @spacer;
 
 // 组合复选框margin
-@checkbox-group-margin: @spacer-2;
+@checkbox-group-gap: @spacer-2;
 // 单个复选框margin
 @checkbox-margin: inherit;


### PR DESCRIPTION
inline-block 底部有幽灵空白节点占据高度，导致formItem 高度没有局中对齐，改为inline-flex布局