### PR TITLE
chore(slider): remove input number width limit

### DIFF
--- a/style/web/components/slider/_index.less
+++ b/style/web/components/slider/_index.less
@@ -22,13 +22,6 @@
     background: @slider-center-line-background;
     margin: @slider-center-line-margin;
   }
-
-  .@{prefix}-input-number {
-    width: @slider-input-width;
-    &.@{prefix}-input-number--row {
-      width: @slider-row-input-width;
-    }
-  }
 }
 
 .@{prefix}-slider {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- 新特性提交 slider的Inputnumber props需要支持autoWidth透传 这个width的现在需要去掉

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-vue-next/issues/544

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
