### PR TITLE
fix(select): wrap when remain width is enough

### DIFF
--- a/style/web/components/select/_index.less
+++ b/style/web/components/select/_index.less
@@ -105,6 +105,9 @@
   // TODO: select_input 重构后可删除
   .@{prefix}-tag + .@{prefix}-input__wrap {
     margin-left: @select-placeholder-margin;
+    .@{prefix}-input__inner {
+      width: 100%;
+    }
   }
 
   // TODO: select_input 重构后可删除


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-vue/issues/726

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

由于之前input内真正的input输入框在input层 重构的Input又增加了一层 之前input的width: 100%实际来到了第二层，
之前不换行依赖flex: 1, width: 100% ，来保证内部input的宽度应该是按现有剩余宽度撑开 保证不会换行；
但是重构之后 真正的Input的width 100%的设置丢失了 input实际是按默认宽度展开的 大概是150左右 所以会出现issue的情况。所以需要再手动给它加上这个配置。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Select): 可过滤的选择器提前换行问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
