### PR TITLE
【新增】拖拽列宽时的标记线样式

### DIFF
--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -72,7 +72,6 @@
     z-index: @table-resize-line-z-index;
   }
 
-
   &__column-controller {
     padding: 16px 0;
   }

--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -19,6 +19,7 @@
 @table-fixed-footer-virtual-scroll-z-index: @table-fixed-footer-z-index + 1;
 @table-right-scrollbar-divider: @table-fixed-row-z-index + 1;
 @table-loading-z-index: @table-right-scrollbar-divider + 1;
+@table-resize-line-z-index: @table-right-scrollbar-divider + 1;
 
 @table-cell-padding: @table-td-padding-vertical-top @table-td-padding-horizontal
   @table-td-padding-vertical-bottom @table-td-padding-horizontal;
@@ -68,6 +69,7 @@
     bottom: 0;
     width: 0;
     border-left: @border;
+    z-index: @table-resize-line-z-index;
   }
 
 

--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -60,6 +60,17 @@
     pointer-events: none;
   }
 
+  .@{prefix}-table__resize-line {
+    display: none;
+    position: absolute;
+    left: 10px;
+    top: 0;
+    bottom: 0;
+    width: 0;
+    border-left: @border;
+  }
+
+
   &__column-controller {
     padding: 16px 0;
   }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ Y ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
需要支持表格列宽可以拖拽改动：
https://github.com/Tencent/tdesign-vue/issues/489

### 💡 需求背景和解决方案

将拖拽列宽时的标记线样式抽取为一个class下的样式

### 📝 更新日志

- upd(table): 增加了表格拖拽列宽时的标记线样式


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
