### PR TITLE
docs: 删除 dialog 下与特定框架语法糖相关的文案

### DIFF
--- a/docs/web/api/dialog.md
+++ b/docs/web/api/dialog.md
@@ -48,31 +48,3 @@ spline: message
 
 {{ attach }}
 
-### 插件函数式调用
-插件调用方式一：`this.$dialog(options)`
-
-插件调用方式二：`this.$dialog.confirm(options)`
-
-插件调用方式三：`this.$dialog.alert(options)`
-
-<br />
-
-函数调用方式一：`DialogPlugin(options)`
-
-函数调用方式二：`DialogPlugin.confirm(options)`
-
-函数调用方式三：`DialogPlugin.alert(options)`
-
-<br />
-
-组件实例：`DialogInstance = this.$dialog(options)` 或者 组件实例：`DialogInstance = DialogPlugin(options)`
-
-组件实例方法-销毁弹框：`DialogInstance.destroy()`
-
-组件实例方法-隐藏弹框：`DialogInstance.hide()`
-
-组件实例方法-显示弹窗：`DialogInstance.show()`
-
-组件实例方法-更新弹框：`DialogInstance.update()`
-
-{{ plugin }}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 文档改进

### 🔗 相关 Issue
 [Dialog] 公共文档中涉及特定框架的语法糖问题 #448 

tdesign-react : https://github.com/Tencent/tdesign-react/issues/713
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案



该问题来自于 tdesign-common 的 md 文案修改。
tdesign-common/dialog 中需要删去关于 “插件函数式调用” 的相关公共描述。理由是该公共描述涉及 vue 特定的语法糖，从而在 tdesign-react 的网站中描述会使读者产生困惑。

根据 @[Kyrielin](https://github.com/HQ-Lin) 的 [描述](https://github.com/Tencent/tdesign-react/issues/713#issuecomment-1120184435)，需从 common 仓库删除，在各自仓库维护。
> 备注：**该 PR 不会对 文案本身产生任何修改，只涉及 md 文案引用方式。**

<img width="940" alt="图片" src="https://user-images.githubusercontent.com/28757633/167283618-d7d397d2-ee23-4d36-a9de-4a39b9893807.png">


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- docs(Dialog): docs: 删除 dialog 下与特定框架语法糖相关的文案


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
