### PR TITLE
fix(menu): resolve collapsed width

### DIFF
--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -257,6 +257,7 @@ a.@{prefix}-menu__item {
 
       .@{prefix}-menu__item {
         padding: 0 14px;
+        justify-content: center;
       }
     }
 


### PR DESCRIPTION
修复 Menu 收起时，图标无法水平居中的问题