### PR TITLE
fix(input-number): rm left align for input-nubmer when use column theme

### DIFF
--- a/style/web/components/input-number/_index.less
+++ b/style/web/components/input-number/_index.less
@@ -242,10 +242,6 @@
     border-radius: @border-radius;
   }
 
-  .@{inputCls}__inner {
-    text-align: left;
-  }
-
   .@{inputNumberCls}__decrease,
   .@{inputNumberCls}__increase {
     width: @input-number-right-button-width;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [✅] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue/issues/913

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 根本问题：.t-input-number.t-is-controls-right .t-input__inner 写死了 text-align: left，并且该 class 的优先级比 .t-align-center > .t-input__inner 的选择器的优先级高

<img width="445" alt="image" src="https://user-images.githubusercontent.com/11224001/170856678-fa64f1dd-e08c-4af6-a217-7fae289fb0d3.png">

2. 去掉 .t-input-number.t-is-controls-right .t-input__inner 的固定左侧对齐，让 theme 样式生效

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(input-number): theme 为 column 时设置 align 失效的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✅] 文档已补充或无须补充
- [✅] 代码演示已提供或无须提供
- [✅] TypeScript 定义已补充或无须补充
- [✅] Changelog 已提供或无须提供
