### PR TITLE
fix: 修复tree组件收起时，没有同步设置子节点expand状态，导致expandParent为true时不能收起的问题

### DIFF
--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -733,7 +733,15 @@ export class TreeNode {
         map.set(node.value, true);
       });
     } else {
-      map.delete(this.value);
+      // 配置了expandParent时需要处理相关节点
+      if (get(tree, 'config.expandParent')) {
+        const shouldNotExpandNodes = this.walk();
+        shouldNotExpandNodes.forEach((node) => {
+          map.delete(node.value);
+        });
+      } else {
+        map.delete(this.value);
+      }
     }
 
     if (options.directly) {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

[<!--
tree 组件 filter 且 expandParent=true时 导致Tree无法折叠收起
-->](https://github.com/Tencent/tdesign-vue/issues/550)

### 💡 需求背景和解决方案

当expandParent为true收起时，同步设置子节点的expand属性为false

### 📝 更新日志

- fix(tree): 修复expandParent为true时点击收起按钮，不能收起的问题


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
