### PR TITLE
fix(tree): 修复 在用户设置的value中包含了disabled选项时，treeNode.checked属性设置不成功 的问题

### DIFF
--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -851,10 +851,10 @@ export class TreeNode {
   }
 
   // 更新选中态属性值
-  public updateChecked(): void {
+  public updateChecked(isFromValueChange?: boolean): void {
     const { tree } = this;
     this.vmCheckable = this.isCheckable();
-    if (this.vmCheckable && !this.disabled) {
+    if (this.vmCheckable && (!this.disabled || isFromValueChange)) {
       this.checked = this.isChecked();
       if (this.checked) {
         tree.checkedMap.set(this.value, true);

--- a/js/tree/tree-store.ts
+++ b/js/tree/tree-store.ts
@@ -519,11 +519,11 @@ export class TreeStore {
   // 替换选中态列表
   public replaceChecked(list: TreeNodeValue[]): void {
     this.resetChecked();
-    this.setChecked(list);
+    this.setChecked(list, true);
   }
 
   // 批量设置选中态
-  public setChecked(list: TreeNodeValue[]): void {
+  public setChecked(list: TreeNodeValue[], isFromValueChange?: boolean): void {
     const { valueMode, checkStrictly, checkable } = this.config;
     if (!checkable) return;
     list.forEach((val: TreeNodeValue) => {
@@ -536,7 +536,7 @@ export class TreeStore {
           });
         } else {
           this.checkedMap.set(val, true);
-          node.updateChecked();
+          node.updateChecked(isFromValueChange);
         }
       }
     });


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
无

### 💡 解决方案

value更改时会触发treeStore.replaceChecked（且这个函数只会在value更改时触发）函数，里面会调用treeNode.updateChecked
之前逻辑：判断 !disabled 的话，更新checked
更改后逻辑：updateChecked判断如果来自valueChange，则不判断disabled逻辑

### 📝 更新日志

fix(tree): 修复 在用户设置的value中包含了disabled选项时，treeNode.checked属性设置不成功 的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
