### PR TITLE
fix(dialog): top 20% -> 20vh

### DIFF
--- a/style/web/components/dialog/_var.less
+++ b/style/web/components/dialog/_var.less
@@ -61,7 +61,8 @@
 // 位置
 @dialog-close-position-top: @spacer-3;
 @dialog-close-position-right: @spacer-3;
-@dialog-top-position-top: 20%;
+// 此处不能使用20% 因为定位是paddingTop 所以20% 会根据屏幕宽度
+@dialog-top-position-top: 20vh;
 
 // 动画
 @dialog-anim-duration: @anim-duration-base;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

top API使用padding-top实现，导致默认top值20%是页面宽度20%，应该修改为20vh
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
