### PR TITLE
fix: tree shoule be expand when filterText null

### DIFF
--- a/js/tree/tree-store.ts
+++ b/js/tree/tree-store.ts
@@ -13,6 +13,7 @@ import {
   TypeTreeFilterOptions,
   TypeRelatedNodesOptions,
   TypeTreeEventState,
+  TypeTreeNodeModel,
 } from './types';
 
 // 构建一个树的数据模型
@@ -55,8 +56,8 @@ export class TreeStore {
   // 树节点过滤器
   public prevFilter: TypeTreeFilter;
 
-  // 一个空节点
-  public nullNode: TreeNode;
+  // 一个空节点 model
+  public nullNodeModel: TypeTreeNodeModel;
 
   public constructor(options: TypeTreeStoreOptions) {
     const config: TypeTreeStoreOptions = {
@@ -96,8 +97,17 @@ export class TreeStore {
     this.updateTimer = null;
     // 在子节点增删改查时，将此属性设置为 true，来触发视图更新
     this.shouldReflow = false;
+    this.initNullNodeModel();
+  }
+
+  // 初始化空节点 model
+  public initNullNodeModel() {
     // 空节点，用于判定当前的 filterText 是否为空，如果 filter(nullNode) 为 true, 那么可以判定 filterText 为空
-    this.nullNode = new TreeNode(this, { value: '', label: '', children: [] });
+    // 这里初始化空节点的方式似乎不是很完美
+    const nullNode = new TreeNode(this, { value: '', label: '', children: [] });
+    this.nullNodeModel = nullNode.getModel();
+    // 需要将节点从树中移除
+    nullNode.remove();
   }
 
   // 配置选项
@@ -649,8 +659,7 @@ export class TreeStore {
     // 则无需处理锁定节点
     if (!currentFilter || typeof currentFilter !== 'function') return;
 
-    const node = this.nullNode.getModel();
-    if (currentFilter(node)) return;
+    if (currentFilter(this.nullNodeModel)) return;
 
     this.prevFilter = config.filter;
     // 构造路径节点map

--- a/js/tree/tree-store.ts
+++ b/js/tree/tree-store.ts
@@ -55,6 +55,9 @@ export class TreeStore {
   // 树节点过滤器
   public prevFilter: TypeTreeFilter;
 
+  // 一个空节点
+  public nullNode: TreeNode;
+
   public constructor(options: TypeTreeStoreOptions) {
     const config: TypeTreeStoreOptions = {
       prefix: 't',
@@ -93,6 +96,8 @@ export class TreeStore {
     this.updateTimer = null;
     // 在子节点增删改查时，将此属性设置为 true，来触发视图更新
     this.shouldReflow = false;
+    // 空节点，用于判定当前的 filterText 是否为空，如果 filter(nullNode) 为 true, 那么可以判定 filterText 为空
+    this.nullNode = new TreeNode(this, { value: '', label: '', children: [] });
   }
 
   // 配置选项
@@ -639,13 +644,15 @@ export class TreeStore {
       });
     }
 
+    const currentFilter = config.filter;
     // 当前没有过滤器
     // 则无需处理锁定节点
-    if (!config.filter) {
-      return;
-    }
-    this.prevFilter = config.filter;
+    if (!currentFilter || typeof currentFilter !== 'function') return;
 
+    const node = this.nullNode.getModel();
+    if (currentFilter(node)) return;
+
+    this.prevFilter = config.filter;
     // 构造路径节点map
     const map = new Map();
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

issue: https://github.com/Tencent/tdesign-vue-next/issues/651
本次 commit 仅解决 issue 中ardorzhang 指出的 bug
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 问题是：只要 filter 有值或者延迟赋值（如官方文档示例），树就不能再折叠了（即便清空 filterText）
2. 如何解决：如果用户的 filterText 为空，就相当于 config.filter 不存在了（可以解锁对应的节点），那么问题是如何判定用户的 filterText 为空呢，方案是只要用户的 filter 函数对空值（空 node）都返回为 true, 那么就可以认为用户的 filterText 为空

### 📝 更新日志

- fix(tree): tree-cannot-expand-filter-null

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
