### PR TITLE
fix(table): darkMode下分页器吸底背景色取值问题

### DIFF
--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -1061,7 +1061,7 @@
 
 /** 吸底的分页器，需要背景色，避免表格文本内容显示穿透 */
 .@{prefix}-affix .@{prefix}-table__pagination {
-  background-color: white;
+  background-color: @table-bg;
 }
 
 .@{prefix}-table--bordered .@{prefix}-affix .@{prefix}-table__pagination {


### PR DESCRIPTION
`dark mode`下`table`组件分页器吸底背景颜色写死了`white`应根据theme变化取`@table-bg`

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

dark mode下table组件分页器吸底背景颜色写死了white应根据theme变化取@table-bg
![image](https://user-images.githubusercontent.com/20508822/178397314-43e86448-102b-485f-8779-c633e2f12c58.png)
<img width="822" alt="image" src="https://user-images.githubusercontent.com/20508822/178397636-6888a844-8a69-4b50-94d5-4da06880ecbd.png">

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): darkMode下分液器吸底背景色取值问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
