### PR TITLE
fix(table): 带边框表格表头吸顶显示错位

### DIFF
--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -990,7 +990,6 @@
   border: @border;
   border-bottom: 0;
   border-right: 0;
-  left: 1px;
 }
 
 .@{prefix}-table--bordered .@{prefix}-table__affixed-footer-elm {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

带边框表格，表头吸顶后显示错位
![image](https://user-images.githubusercontent.com/20508822/178435583-89467a27-e5ed-4d37-a2d4-ba7a8858f433.png)
<img width="674" alt="image" src="https://user-images.githubusercontent.com/20508822/178435816-b18bca8d-2b91-4ed4-92d3-62578d44b9c3.png">
`left`属性去除后可显示正常

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 带边框表格表头吸顶显示错位

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
