### PR TITLE
feat: optimize select styles

### DIFF
--- a/style/web/components/select/_index.less
+++ b/style/web/components/select/_index.less
@@ -252,6 +252,7 @@
   padding: 0; // 展开动画 如果有padding会直接生长 需要移动到内部
   max-height: @select-dropdown-max-height;
   overflow-y: auto;
+  border: @select-dropdown-border;
   box-shadow: @select-dropdown-shadow;
   border-radius: @select-border-radius;
 
@@ -315,7 +316,17 @@
 }
 
 .@{prefix}-select-option-group__divider + .@{prefix}-select-option-group__divider {
-  border-top: 1px @select-optiongroup-border-color solid;
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    left: 8px;
+    right: 28px;
+    top: 0;
+    height: 1px;
+    background-color: @select-optiongroup-border-color;
+  }
 }
 
 .@{prefix}-select-option-group__header {
@@ -343,7 +354,8 @@
 
 // option
 .@{prefix}-select-option {
-  display: block;
+  display: flex;
+  align-items: center;
   border-radius: @select-option-border-radius;
   height: @select-option-height-default;
   line-height: @select-option-line-height;
@@ -461,6 +473,33 @@
 
       .@{prefix}-fake-arrow {
         color: @select-border-color-active;
+      }
+    }
+  }
+}
+
+// 覆盖input中的padding
+.@{prefix}-select {
+
+  .@{prefix}-input {
+    line-height: @select-line-height;
+
+    .@{prefix}-input__inner {
+      font-size: @font-size-base;
+    }
+
+    &.@{prefix}-size-l {
+      padding: @spacer @spacer-l;
+
+      .@{prefix}-input__inner {
+        font-size: @font-size-l;
+      }
+    }
+
+    &.@{prefix}-size-s {
+
+      .@{prefix}-input__inner {
+        font-size: @font-size-s;
       }
     }
   }

--- a/style/web/components/select/_var.less
+++ b/style/web/components/select/_var.less
@@ -8,7 +8,7 @@
 @select-option-bg-color-hover: @bg-color-container-hover;
 @select-option-bg-color-active: @bg-color-container-active;
 @select-option-checkbox-color: @bg-color-container-hover;
-@select-option-group-header-color: @text-color-placeholder;
+@select-option-group-header-color: @text-color-disabled;
 @select-option-color: @text-color-primary;
 @select-bg-color-disabled: @bg-color-component-disabled;
 @select-placeholder-color: @text-color-placeholder; // 如果需要改变文字颜色的透明度请通过这里修改
@@ -35,6 +35,7 @@
 @select-tag-height-default: 22px;
 @select-tag-height-l: 30px;
 @select-tag-height-s: 18px;
+@select-line-height: 30px;
 
 // font-size
 @select-font-size-s: @font-size-s;
@@ -53,7 +54,7 @@
 // padding
 @select-option-padding-s: 0 8px;
 @select-option-padding-default: 3px 8px;
-@select-option-padding-l: 7px 12px;
+@select-option-padding-l: 6px 12px;
 @select-padding: 0 26px 0 4px;
 @select-optiongroup-border-padding: 7px;
 @select-padding-prefix: 26px;
@@ -69,3 +70,5 @@
 @select-dropdown-margin: 8px 0;
 @select-options-margin: 2px;
 @select-no-border-margin-right: @spacer;
+// border
+@select-dropdown-border: .5px solid @gray-color-4;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[148](https://github.com/Tencent/tdesign/issues/148)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
优化了部分select公共样式

【问题1】下拉菜单缺少描边。
【方案1】描边样式为：gray4/0.5/inside。
~~【问题2】多选选择器，选中态字体颜色不对。(问题不存在)~~
~~【【方案2】应为brand8-normal。~~
【问题3】分组选择器，分割线的margin和padding不对。
【方案3】间距为2。分割线的padding为2，8，2，8。
【问题4】分组选择器，下拉菜单中，【分组】的样式透明度不对。
【方案4】应为26%。
【问题5】大尺寸输入框padding不对。
【方案5】应为12。
【问题6】大/中尺寸输入框中字号不对。
【方案6】分别应为16、14。
【建议7】【不同尺寸的选择器】中，建议小尺寸的下拉菜单为240，即与输入框保持一致。
【问题8】下拉菜单中，选中项没有居中对齐。
【方案8】文字纵向需居中对齐。
~~【【问题9】自定义下拉选项选择器样式不对。（高度为用户自定义）~~
~~【【方案9】下拉菜单选项中，内容区上下padding应为3。~~
【问题10】自定义面板选择器，下拉菜单选中态的padding不对。
【方案10】选中态的padding为8，且状态为【fill】，而不是hug。
【问题11】自定义选中项选择器，输入框高度不对。
【方案11】应为32。
【问题12】大尺寸中下拉菜单中，选中态的padding不对。
【方案12】padding值为6，12，6，12。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(select): 优化了部分样式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
