### PR TITLE
fix: popup word-break

### DIFF
--- a/docs/web/api/table.md
+++ b/docs/web/api/table.md
@@ -319,7 +319,7 @@ spline: data
 - `onRowEdit` 会在行编辑时触发。
 - `onRowValidate` 在行编辑校验完成后触发。
 - `editableRowKeys` 用于控制处于编辑状态的行。
-- 实例方法 `validateRowDate` 用于进行表格行数据校验。
+- 实例方法 `validateRowData` 用于进行表格行数据校验。
 
 {{ editable-row }}
 

--- a/style/web/components/popup/_index.less
+++ b/style/web/components/popup/_index.less
@@ -26,6 +26,7 @@
     font-size: @popup-content-font-size;
     line-height: @popup-content-line-height;
     box-sizing: border-box;
+    word-break: break-all;
   }
 
   &__reference {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

https://github.com/Tencent/tdesign-vue-next/issues/1318

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popup): 修复 `content` 为纯英文时无法自动换行  ([issue #1318](https://github.com/Tencent/tdesign-vue-next/issues/1318))
- docs(Table): 修复 `validateRowDate` 拼写错误到 `validateRowData`  ([issue #1321](https://github.com/Tencent/tdesign-vue-next/issues/1321))

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
