### PR TITLE
docs(Button): support href and tag

### DIFF
--- a/docs/web/api/button.md
+++ b/docs/web/api/button.md
@@ -69,3 +69,9 @@ Block 按钮在宽度上充满其所在的父容器（无 padding 和 margin 值
 提供长方形、正方形、圆角长方形、圆形四种形状。
 
 {{ shape }}
+
+### 自定义渲染元素
+
+支持自定义渲染元素，支持 `div/a/button`
+
+{{ custom-element }}


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 新特性提交

### 🔗 相关 Issue

[Button] 支持 href 和 tag 属性：https://github.com/Tencent/tdesign-vue/issues/1279

### 💡 需求背景和解决方案

根据 tag 渲染 button 的根元素。
> 其中 href 存在时，按钮标签默认使用 <a> 渲染；如果指定了 tag 则使用指定的标签渲染

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
