### PR TITLE
fix(tabs): fix overflowing scrollbar

### DIFF
--- a/style/mobile/components/tabs/_index.less
+++ b/style/mobile/components/tabs/_index.less
@@ -10,9 +10,9 @@
   flex-direction: column;
 
   &__nav {
-    width: 100vw;
+    width: 100%;
     position: relative;
-    overflow: scroll;
+    overflow: auto;
     user-select: none;
     white-space: nowrap;
     background-color: @tab-nav-bg-color;
@@ -99,6 +99,7 @@
     }
 
     .@{prefix}-tabs__nav {
+      width: initial;
       background-color: @tab-nav-horizontal-bg-color;
 
       &-wrap {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

[tabs] 选项卡label和panel内容之间存在间隙， 超出屏幕时出现滚动条 [tdesign-mobile-vue#276](https://github.com/Tencent/tdesign-mobile-vue/issues/276)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

mobile-vue 和 mobile-react 同时存在以下问题

- 在 macOS（12.4）下启用 `始终` 显示滚动条
  <img width="315" alt="image" src="https://user-images.githubusercontent.com/30434733/185294102-1cc76fda-415d-4c77-a5f9-ff13870b1252.png">
  滚动条会导致溢出
  <img width="423" alt="image" src="https://user-images.githubusercontent.com/30434733/185294385-6a36be78-4c66-4ce1-bcbd-cfecb0a726c4.png">
- 在 Windows 11 下，会出现非预期的滚动条
  <img width="486" alt="image" src="https://user-images.githubusercontent.com/30434733/185294712-5cc90335-79e5-4d3e-bdcd-d5c015b6763b.png">
- 第三组 demo 没展示出实例内容
  <img width="426" alt="image" src="https://user-images.githubusercontent.com/30434733/185294941-a3d685d6-cbcd-4375-968b-d32fc62dd3ea.png">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tabs): 修复选项卡内容超出屏幕时滚动条溢出的问题
- fix(tabs): 修复竖向选项卡 demo 内容区未展示的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
