### PR TITLE
fix(loading): fix the abnormal icon display on iOS

### DIFF
--- a/js/loading/circle-adapter.ts
+++ b/js/loading/circle-adapter.ts
@@ -13,7 +13,7 @@ export default function circleAdapter(circleElem: HTMLElement) {
   // to fix the browser compat of foreignObject in Safari,
   // https://bugs.webkit.org/show_bug.cgi?id=23113
   const ua = window?.navigator?.userAgent;
-  const isSafari = /Safari/.test(ua) && !/Chrome/.test(ua);
+  const isSafari = /(?=.*iPhone)[?=.*MicroMessenger]/.test(ua) && !/Chrome/.test(ua);
   if (isSafari) {
     basicStyle = {
       transformOrigin: '-1px -1px',


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

[Loading] 加载组件的Icon在ios端显示异常 [tdesign-mobile-vue#281](https://github.com/Tencent/tdesign-mobile-vue/issues/281)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

在 iOS 端的微信和企业微信使用 loading 组件，icon 显示异常，tdesign-mobile-vue、tdesign-mobile-react、tdesign-react 等仓库都可复现

![IMG_2835](https://user-images.githubusercontent.com/30434733/185528213-6ecb7b8b-73f4-4032-937f-68d0093d4efb.PNG)

![IMG_2836](https://user-images.githubusercontent.com/30434733/185528220-5f48c5cb-7f02-4fe2-9108-e5815e5b81f5.PNG)

经过排查是 tdesign-common 中的 `circleAdapter()` 对于 iOS 端微信和企业微信的 UA 判断不足，没有处理到这种情况下 webkit 的 bug

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(loading): 修复加载组件的 icon 在 iOS 端微信和企业微信显示异常的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
