### PR TITLE
fix: tree setData support keys

### DIFF
--- a/js/tree/tree-node-model.ts
+++ b/js/tree/tree-node-model.ts
@@ -150,7 +150,13 @@ export function createNodeModel(node: TreeNode): TypeTreeNodeModel {
     // 设置本节点携带的元数据
     setData(data: OptionData) {
       // 详细细节可见 https://github.com/Tencent/tdesign-common/issues/655
-      const _data = omit(data, ['children']);
+      const _data = omit(data, ['children', 'value', 'label']);
+      const { keys } = node.tree.config;
+      const dataValue = data[keys?.value || 'value'];
+      const dataLabel = data[keys?.label || 'label'];
+      if (dataValue !== undefined) _data.value = dataValue;
+      if (dataLabel !== undefined) _data.label = dataLabel;
+
       Object.assign(node.data, _data);
       Object.assign(node, _data);
     },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

通过keys指定字段别名在setData中不生效：https://github.com/Tencent/tdesign-vue-next/issues/1513

### 💡 需求背景和解决方案

`setData` 支持 `keys` 别名

### 📝 更新日志

- fix(Tree): `setData` 支持 `keys` 别名

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
