### PR TITLE
style: fix tabs select horizontal line style

### DIFF
--- a/style/web/components/tabs/_index.less
+++ b/style/web/components/tabs/_index.less
@@ -191,6 +191,7 @@
     background-color: @tab-default-bar-bg-color;
     z-index: 1;
     transition: @tab-bar-transition;
+    border-radius: @tab-default-stroke-border-radius;
 
     &.@{prefix}-is-top {
       bottom: 0;

--- a/style/web/components/tabs/_var.less
+++ b/style/web/components/tabs/_var.less
@@ -26,7 +26,8 @@
 
 @tab-default-stroke: @component-stroke;
 @tab-default-bar-bg-color: @brand-color;
-@tab-default-stroke-size: 2px;
+@tab-default-stroke-size: 3px;
+@tab-default-stroke-border-radius: 2px;
 
 // 卡片选项卡
 @tab-card-bg: @bg-color-secondarycontainer;


### PR DESCRIPTION
修复tabs组件选中横线样式不对问题

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[#1487](https://github.com/Tencent/tdesign-vue/issues/1487)


### 💡 需求背景和解决方案

上下布局选中横线height=3px；左右布局选中横线width=3px
上下布局增加圆角为2px；左右布局增加圆角2px

修复前
<img width="775" alt="image" src="https://user-images.githubusercontent.com/45997005/190411670-c8c84094-186f-4fd4-b748-0d1b96e02aad.png">

修复后
<img width="776" alt="image" src="https://user-images.githubusercontent.com/45997005/190412117-3751b4ee-2907-4064-955d-bb793e21843f.png">


### 📝 更新日志

- fix(tabs): 修改选中横线样式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
