### PR TITLE
fix treeselect default status paading-left error

### DIFF
--- a/style/web/components/select/_index.less
+++ b/style/web/components/select/_index.less
@@ -274,7 +274,7 @@
 
     &--size-l {
       .@{prefix}-select__list,
-      .@{prefix}-tree  {
+      .@{prefix}-tree {
         padding: @select-dropdown-padding-l;
       }
     }

--- a/style/web/components/select/_index.less
+++ b/style/web/components/select/_index.less
@@ -47,7 +47,7 @@
   }
 
   .@{prefix}-select__placeholder {
-    margin-left: @select-placeholder-margin;
+    margin-left: 8px;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/style/web/components/select/_index.less
+++ b/style/web/components/select/_index.less
@@ -260,18 +260,21 @@
   }
 
   &-inner {
-    .@{prefix}-select__list {
+    .@{prefix}-select__list,
+    .@{prefix}-tree {
       padding: @select-dropdown-padding;
     }
 
     &--size-s {
-      .@{prefix}-select__list {
+      .@{prefix}-select__list,
+      .@{prefix}-tree {
         padding: @select-dropdown-padding-s;
       }
     }
 
     &--size-l {
-      .@{prefix}-select__list {
+      .@{prefix}-select__list,
+      .@{prefix}-tree  {
         padding: @select-dropdown-padding-l;
       }
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[Vue Next #229](https://github.com/Tencent/tdesign/issues/229)  

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
#### 问题 1  treeSelect popupContent 缺少内部 padding
请查看 其他组件库 PR 
[Vue2 #1539](https://github.com/Tencent/tdesign-vue-next/pull/1539)
[Vue3 #1714](https://github.com/Tencent/tdesign-vue-next/pull/1714)

React 
treeSelect 在 popup 内的结构与其他组件库不一致，会使用 popup 默认的 4px padding，暂未修改。
<img width="604" alt="image" src="https://user-images.githubusercontent.com/15060047/191398103-a9aedd9b-c91c-4f35-871c-6f212a4aca81.png">


#### 问题 2 placeholder 无左边距
**仅在 Vue2 版本下有问题**
TreeSelect 组件在默认没有选中任何值时，直接使用 <span class="t-select__placeholder">请选择</span> 显示 placeholder 元素，缺少了其他场景下的 tag-prefix 4px。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
