### PR TITLE
feat(table): 列宽调整策略支持 resize-sibling-column 和 resize-table 两种模式

### DIFF
--- a/js/table/recalculate-column-width.ts
+++ b/js/table/recalculate-column-width.ts
@@ -132,6 +132,7 @@ export default function recalculateColumnWidth<T extends BaseTableCol<T>>(
   tableLayout: string,
   tableElmWidth: number,
   notCalculateWidthCols: string[],
+  columnResizeType: 'resize-sibling-column' | 'resize-table',
   callback: (widthMap: { [colKey: string]: number }) => void
 ): void {
   let actualWidth = 0;
@@ -181,13 +182,16 @@ export default function recalculateColumnWidth<T extends BaseTableCol<T>>(
       }
       // 重新计算其他列的宽度，按表格剩余宽度进行按比例分配
       if (actualWidth !== tableWidth || notCalculateWidthCols.length) {
-        setNormalColumnWidth(
-          columns,
-          thMap,
-          actualWidth,
-          tableWidth,
-          notCalculateWidthCols
-        );
+        // 如果是关联更新模式，需要按比例重新计算各列宽度，否则不重新计算
+        if (columnResizeType === 'resize-sibling-column') {
+          setNormalColumnWidth(
+            columns,
+            thMap,
+            actualWidth,
+            tableWidth,
+            notCalculateWidthCols
+          );
+        }
         needUpdate = true;
       }
     }

--- a/js/table/recalculate-column-width.ts
+++ b/js/table/recalculate-column-width.ts
@@ -132,8 +132,8 @@ export default function recalculateColumnWidth<T extends BaseTableCol<T>>(
   tableLayout: string,
   tableElmWidth: number,
   notCalculateWidthCols: string[],
-  columnResizeType: 'resize-sibling-column' | 'resize-table',
-  callback: (widthMap: { [colKey: string]: number }) => void
+  callback: (widthMap: { [colKey: string]: number }) => void,
+  columnResizeType: 'resize-sibling-column' | 'resize-table' = 'resize-sibling-column',
 ): void {
   let actualWidth = 0;
   const missingWidthCols: T[] = [];

--- a/js/table/set-column-width-by-drag.ts
+++ b/js/table/set-column-width-by-drag.ts
@@ -188,11 +188,11 @@ export default function setThWidthListByColumnDrag<T extends BaseTableCol<T>>(
   options: {
     getThWidthList: () => ThMap,
     DEFAULT_MIN_WIDTH: number,
-    columnResizeType: 'resize-sibling-column' | 'resize-table'
+    columnResizeType?: 'resize-sibling-column' | 'resize-table'
   },
   callback: (widthMap: ThMap, colKeys: string[]) => void
 ): void {
-  const { columnResizeType, ...opt } = options;
+  const { columnResizeType = 'resize-sibling-column', ...opt } = options;
   if (columnResizeType === 'resize-sibling-column') {
     setThWidthListByColumnDragWithSiblingColumns(dragCol, dragWidth, effectCol, opt, callback);
   } else {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue/issues/1340

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 调整 setThWidthListByColumnDrag 和 recalculateColumnWidth 使其支持两种resizeType

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(table): 列宽调整策略支持 resize-sibling-column 和 resize-table 两种模式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
