### PR TITLE
fix: tag input padding left

### DIFF
--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -14,7 +14,6 @@
   }
 
   .@{prefix}-input {
-    padding-left: @spacer-s;
     overflow: hidden;
 
     &.@{prefix}-size-s {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/1907

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题原因：
`.t-tag-input` 覆盖了 `.t-input` 原本的内边距。

[复现连接](https://tdesign.tencent.com/vue-next/components/select#远程搜索选择器)
一个是基于 `SelectInput` 开发，一个是基于 `TagInput` 开发。`TagInput` 重写了左右边距，左边距设为了4px，与 `Input` 默认值8px不一致，导致不规范。

<img width="550" alt="image" src="https://user-images.githubusercontent.com/15711610/199045046-735163d0-7a6a-45ad-856f-4b0a7d103491.png">

解决方法：
和 Input 的左边距统一
src/_common/style/web/components/tag-input/_index.less
```diff
.@{prefix}-tag-input {
  .reset;
  .@{prefix}-tag {
    margin-right: @spacer-s;
    animation: t-fade-in .1s ease-in-out;
  }

  .@{prefix}-input {
-   padding-left: @spacer-s;
    overflow: hidden;

    &.@{prefix}-size-s {
      padding-left: @spacer-s * .5;
    }
  }
  // ...
}
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TagInput): 样式统一

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
