### PR TITLE
fix(TagInput): 修复TagInput的excessTagsDisplayType属性，设置为scroll时无效的问题

### DIFF
--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -64,6 +64,32 @@
   }
 }
 
+// 标签数量超出时，横向滚动显示
+.@{prefix}-tag-input--scroll {
+
+  .@{prefix}-input {
+    display: flex;
+    padding-right: @spacer-3;
+
+    &.@{prefix}-input--prefix > .@{prefix}-input__prefix {
+      display: inline-flex;
+      text-align: left;
+      overflow-x: scroll;
+      width: auto;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+
+    .@{prefix}-input__suffix-icon {
+      position: absolute;
+      right: @spacer;
+      bottom: 0;
+    }
+  }
+}
+
 .@{prefix}-tag-input__prefix {
   width: max-content;
   display: inline-block;

--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -80,6 +80,13 @@
       &::-webkit-scrollbar {
         display: none;
       }
+
+      /* firefox */
+      scrollbar-width: none;
+      overflow: -moz-scrollbars-none;
+
+      /* IE 10+ */
+      -ms-overflow-style: none;
     }
 
     .@{prefix}-input__suffix-icon {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue


### 💡 需求背景和解决方案

TagInput的excessTagsDisplayType属性，设置为scroll时无效的问题。
在组件实现和示例中，都没有实现scroll这个显示类型。
参考这个示例 https://tdesign.woa.com/vue-next/components/tag-input#%E6%A0%87%E7%AD%BE%E6%95%B0%E9%87%8F%E8%B6%85%E5%87%BA%E7%9A%84%E8%BE%93%E5%85%A5%E6%A1%86
<img width="980" alt="示例" src="https://user-images.githubusercontent.com/16323760/200505521-a1cb4a10-02cb-4ecd-b8a6-4f06e3373ada.png">

https://github.com/Tencent/tdesign-vue-next仓库会提交一条同名PR：https://github.com/Tencent/tdesign-vue-next/pull/1984，共同修复上面的问题。

### 📝 更新日志

fix: 修复TagInput的excessTagsDisplayType属性，设置为scroll时无效的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
