### PR TITLE
fix: 修复日历组件中右上角控件栏下拉框垂直对齐的问题。

### DIFF
--- a/style/web/components/calendar/_index.less
+++ b/style/web/components/calendar/_index.less
@@ -258,6 +258,7 @@
         }
 
         .@{prefix}-select {
+          display: inline;
 
           &.@{prefix}-size-l {
             padding-right: @calendar-control-section-cell-select-padding-left-l;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

自测发现，无 issue。

### 💡 需求背景和解决方案

vue3 版本目前获取最新代码后日历组件右上角控件栏的下拉框直对齐有问题。

### 📝 更新日志

fix: 修复日历组件中右上角控件栏下拉框垂直对齐的问题。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
