### PR TITLE
[TagInput] tag padding

### DIFF
--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -75,8 +75,10 @@
     margin-right: 0;
   }
 
-  .@{prefix}-input--auto-width {
-    padding-right: @comp-paddingLR-xs;
+  &.@{prefix}-input--auto-width {
+    .@{prefix}-input__prefix {
+      white-space: nowrap;
+    }
   }
 }
 

--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -28,6 +28,9 @@
     &.@{prefix}-size-s {
       padding: 0 @comp-paddingLR-xxs 0 @comp-margin-xs;
       min-height: @tag-input-height-s;
+      .@{prefix}-tag {
+        margin: 1px @comp-margin-xs 1px 0;
+      }
     }
 
     &.@{prefix}-size-l {
@@ -54,10 +57,6 @@
 
     .@{prefix}-input__inner {
       margin-top: calc(@comp-margin-xs - 1px);
-    }
-
-    .@{prefix}-size-s .@{prefix}-tag {
-      margin: 1px @comp-margin-xs 1px 0;
     }
 
     .@{prefix}-input__inner {

--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -8,12 +8,11 @@
 
 .@{prefix}-tag-input {
   .reset;
+
   .@{prefix}-tag {
     animation: t-fade-in @anim-duration-base ease-in-out;
   }
-  .@{prefix}-tag + .@{prefix}-tag {
-    margin-left: @comp-margin-xs;
-  }
+
   .@{prefix}-tag-input__drag_wrapper + .@{prefix}-tag-input__drag_wrapper {
     margin-left: @comp-margin-xs;
   }
@@ -21,19 +20,18 @@
   .@{prefix}-input {
     overflow: hidden;
     min-height: @tag-input-height-default;
-    line-height: @tag-input-line-height-default;
-    padding: 0 @comp-paddingLR-xs;
+    padding: @comp-margin-xxs @comp-paddingLR-xs 0 @comp-paddingLR-xs;
     height: fit-content;
+    .t-input-margin-size(@comp-margin-xs, @comp-margin-xxs);
 
     &.@{prefix}-size-s {
-      padding: calc(@comp-paddingTB-xxs - 1px) @comp-paddingLR-xs;
+      padding: 1px @comp-paddingLR-xxs 0 @comp-margin-xs;
       min-height: @tag-input-height-s;
-      line-height: @tag-input-line-height-s;
+      .t-input-margin-size(@comp-margin-xxs, 1px);
     }
 
     &.@{prefix}-size-l {
       min-height: @tag-input-height-l;
-      line-height: @tag-input-line-height-l;
     }
   }
 
@@ -63,7 +61,6 @@
 
   .@{prefix}-input {
     display: block;
-    padding-right: @comp-paddingLR-xl;
 
     &.@{prefix}-input--prefix > .@{prefix}-input__prefix {
       display: inline;
@@ -72,8 +69,11 @@
 
     .@{prefix}-input__suffix-icon {
       position: absolute;
-      right: @comp-margin-s;
       bottom: 0;
+    }
+
+    &.@{prefix}-size-s {
+      padding-top: 0;
     }
   }
 }

--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -11,6 +11,7 @@
 
   .@{prefix}-tag {
     animation: t-fade-in @anim-duration-base ease-in-out;
+    margin: @comp-margin-xxs @comp-margin-xs @comp-margin-xxs 0;
   }
 
   .@{prefix}-tag-input__drag_wrapper + .@{prefix}-tag-input__drag_wrapper {
@@ -20,18 +21,42 @@
   .@{prefix}-input {
     overflow: hidden;
     min-height: @tag-input-height-default;
-    padding: @comp-margin-xxs @comp-paddingLR-xs 0 @comp-paddingLR-xs;
     height: fit-content;
-    .t-input-margin-size(@comp-margin-xs, @comp-margin-xxs);
+    padding: 1px @comp-paddingLR-s 1px @comp-margin-xs;
+    .t-input-suffix-icon(@comp-margin-s);
 
     &.@{prefix}-size-s {
-      padding: 1px @comp-paddingLR-xxs 0 @comp-margin-xs;
+      padding: 0 @comp-paddingLR-xxs 0 @comp-margin-xs;
       min-height: @tag-input-height-s;
-      .t-input-margin-size(@comp-margin-xxs, 1px);
     }
 
     &.@{prefix}-size-l {
       min-height: @tag-input-height-l;
+      padding-right: @comp-paddingLR-m;
+      .t-input-suffix-icon(@comp-margin-m);
+    }
+  }
+
+  /** 设计稿：未填充标签场景，边距和已填充不同 */
+  &.@{prefix}-is-empty {
+    .@{prefix}-input {
+      padding-top: @comp-margin-xs;
+
+      &.@{prefix}-size-s {
+        padding-top: 1px;
+
+        .@{prefix}-tag {
+          margin: 1px @comp-margin-xs 1px 0;
+        }
+      }
+
+      &.@{prefix}-size-l {
+        padding-top: calc(@comp-margin-s - 1px);
+      }
+    }
+
+    .@{prefix}-input__inner {
+      margin-left: @comp-margin-xs;
     }
   }
 
@@ -42,9 +67,12 @@
     }
   }
 
-  .@{prefix}-tag-input__prefix,
-  .@{prefix}-input__prefix:empty + input {
+  .@{prefix}-tag-input__prefix {
     margin-left: @comp-margin-xs;
+  }
+
+  .@{prefix}-input .@{prefix}-input__prefix:not(:empty) {
+    margin-right: 0;
   }
 
   .@{prefix}-input--auto-width {
@@ -71,10 +99,6 @@
       position: absolute;
       bottom: 0;
     }
-
-    &.@{prefix}-size-s {
-      padding-top: 0;
-    }
   }
 }
 
@@ -82,4 +106,25 @@
   width: max-content;
   display: inline-block;
   margin-right: @comp-margin-s;
+}
+
+/** 避免标签和右侧图标重合，需保留图标宽度 22px 和左侧距离标签间距 8px */
+.@{prefix}-tag-input {
+  &.@{prefix}-tag-input--with-tag {
+    .@{prefix}-input__prefix {
+      padding-right: @tag-input-clear-icon-padding-m;
+    }
+    .@{prefix}-input__inner {
+      margin-left: calc(-1 * @tag-input-clear-icon-padding-m);
+    }
+
+    .@{prefix}-size-l {
+      .@{prefix}-input__prefix {
+        padding-right: @tag-input-clear-icon-padding-l;
+      }
+      .@{prefix}-input__inner {
+        margin-left: calc(-1 * @tag-input-clear-icon-padding-l);
+      }
+    }
+  }  
 }

--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -39,20 +39,25 @@
 
   /** 设计稿：未填充标签场景，边距和已填充不同 */
   &.@{prefix}-is-empty {
-    .@{prefix}-input {
-      padding-top: @comp-margin-xs;
 
-      &.@{prefix}-size-s {
-        padding-top: 1px;
-
-        .@{prefix}-tag {
-          margin: 1px @comp-margin-xs 1px 0;
-        }
+    .@{prefix}-size-s {
+      .@{prefix}-input__inner {
+        margin-top: 0;
       }
+    }
 
-      &.@{prefix}-size-l {
-        padding-top: calc(@comp-margin-s - 1px);
+    .@{prefix}-size-l {
+      .@{prefix}-input__inner {
+        margin-top: calc(@comp-margin-s - 1px);
       }
+    }
+
+    .@{prefix}-input__inner {
+      margin-top: calc(@comp-margin-xs - 1px);
+    }
+
+    .@{prefix}-size-s .@{prefix}-tag {
+      margin: 1px @comp-margin-xs 1px 0;
     }
 
     .@{prefix}-input__inner {
@@ -76,6 +81,11 @@
   }
 
   &.@{prefix}-input--auto-width {
+
+    .@{prefix}-input.@{prefix}-input--focused {
+      padding-right: @tag-input-clear-icon-padding-m;
+    }
+
     .@{prefix}-input__prefix {
       white-space: nowrap;
     }

--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -138,5 +138,5 @@
         margin-left: calc(-1 * @tag-input-clear-icon-padding-l);
       }
     }
-  }  
+  }
 }

--- a/style/web/components/tag-input/_var.less
+++ b/style/web/components/tag-input/_var.less
@@ -2,9 +2,7 @@
 @tag-input-height-default: @comp-size-m;
 @tag-input-height-l: @comp-size-xl;
 
-// @tag-input-padding-s: calc(@comp-margin-xs - 1px);
 @tag-input-padding-default: calc(@comp-margin-xs - 1px);
-// @tag-input-padding-l: calc(@comp-margin-xs - 1px);
 
 @tag-input-clear-icon-padding-m: calc(@comp-paddingLR-xxl - @comp-paddingLR-xxs);
 @tag-input-clear-icon-padding-l: calc(@comp-paddingLR-xxl + @comp-paddingLR-xs);

--- a/style/web/components/tag-input/_var.less
+++ b/style/web/components/tag-input/_var.less
@@ -5,3 +5,17 @@
 @tag-input-line-height-s: calc(@tag-input-height-s - 4px);
 @tag-input-line-height-default: calc(@tag-input-height-default - 4px);
 @tag-input-line-height-l: calc(@tag-input-height-l - 4px);
+
+.t-input-margin-size(@distance-x, @distance-y) {
+  .@{prefix}-tag {
+    margin-bottom: @distance-y;
+  }
+
+  .@{prefix}-tag:not(:last-child) {
+    margin-right: @distance-x;
+  }
+
+  .@{prefix}-input__suffix-icon {
+    right: @distance-x;
+  }
+}

--- a/style/web/components/tag-input/_var.less
+++ b/style/web/components/tag-input/_var.less
@@ -2,20 +2,15 @@
 @tag-input-height-default: @comp-size-m;
 @tag-input-height-l: @comp-size-xl;
 
-@tag-input-line-height-s: calc(@tag-input-height-s - 4px);
-@tag-input-line-height-default: calc(@tag-input-height-default - 4px);
-@tag-input-line-height-l: calc(@tag-input-height-l - 4px);
+// @tag-input-padding-s: calc(@comp-margin-xs - 1px);
+@tag-input-padding-default: calc(@comp-margin-xs - 1px);
+// @tag-input-padding-l: calc(@comp-margin-xs - 1px);
 
-.t-input-margin-size(@distance-x, @distance-y) {
-  .@{prefix}-tag {
-    margin-bottom: @distance-y;
-  }
+@tag-input-clear-icon-padding-m: calc(@comp-paddingLR-xxl - @comp-paddingLR-xxs);
+@tag-input-clear-icon-padding-l: calc(@comp-paddingLR-xxl + @comp-paddingLR-xs);
 
-  .@{prefix}-tag:not(:last-child) {
-    margin-right: @distance-x;
-  }
-
+.t-input-suffix-icon(@distance) {
   .@{prefix}-input__suffix-icon {
-    right: @distance-x;
+    right: @distance;
   }
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

React: https://github.com/Tencent/tdesign-react/pull/1758
Vue2: https://github.com/Tencent/tdesign-vue/pull/1860
Vue3: https://github.com/Tencent/tdesign-vue-next/pull/2087

补充：https://github.com/Tencent/tdesign-common/pull/1048
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TagInput): 不同尺寸的间距和高度问题修复，[tdesign-vue#1843](https://github.com/Tencent/tdesign-vue/issues/1843)
- fix(TagInput): 右侧图标会和标签重合问题

<img width="1397" alt="企业微信截图_f049fca1-65e9-4841-b887-d649256a402b" src="https://user-images.githubusercontent.com/11605702/204300477-09db1f6b-da17-4065-920b-15c1febe116e.png">

<img width="1376" alt="企业微信截图_d5d11c7e-2feb-4165-bb81-fdf3768d01f5" src="https://user-images.githubusercontent.com/11605702/204300524-85f46e1b-3f1a-4980-97bc-1859e0d0fa73.png">

<img width="1357" alt="企业微信截图_4860f7ea-ed43-48e8-bffa-60d420336b93" src="https://user-images.githubusercontent.com/11605702/204300826-ef9c957d-629b-4ee6-b57b-ebad5c2c7342.png">




- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
