### PR TITLE
fix(web): select-input icon padding-right

### DIFF
--- a/style/web/components/select-input/_index.less
+++ b/style/web/components/select-input/_index.less
@@ -4,15 +4,24 @@
 
 @import "../../mixins/_reset.less";
 
-.@{prefix}-select-input,
-.@{prefix}-select-input__wrap {
+.@{prefix}-select-input {
   .reset;
 
   width: 100%;
   display: inline-block;
 }
 
-// TODO borderless input 内置
+/** 宽度自适应场景，多选，预留图标的位置 */
+.@{prefix}-select-input--multiple {
+  .@{prefix}-input--auto-width.@{prefix}-tag-input__with-suffix-icon {
+    .@{prefix}-input {
+      padding-right: @comp-paddingLR-xl;
+    }
+    .@{prefix}-input.@{prefix}-size-l {
+      padding-right: calc(@comp-paddingLR-xl + @comp-paddingLR-s);
+    }
+  }
+}
 
 /** 无边框模式 */
 .@{prefix}-select-input--borderless {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(SelectInput): 多选场景，带图标的右侧需要合适的右边距


**TagInput 不需要右边距，但是带图标的情况下需要右边距**

<img width="382" alt="image" src="https://user-images.githubusercontent.com/11605702/205838229-333515db-e7d7-4ccf-981f-d9a1d457c4e7.png">

<img width="330" alt="image" src="https://user-images.githubusercontent.com/11605702/205838383-92f3746a-cf64-44cc-a82d-b78c832765fa.png">


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
