### PR TITLE
fix: menu-item 设置href属性后的样式问题

### DIFF
--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -186,6 +186,9 @@ a.@{prefix}-menu__item {
       .@{prefix}-menu__item {
         padding: 0 14px;
         justify-content: center;
+        .@{prefix}-menu__item-link {
+          display: none;
+        }
       }
     }
 
@@ -629,6 +632,7 @@ a.@{prefix}-menu__item {
 
       &.@{prefix}-menu__item-link {
         color: unset;
+        flex: 1;
       }
     }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[menu-item 使用:href 属性时, icon图标显示异常(小) #2452](https://github.com/Tencent/tdesign-vue-next/issues/2452)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 解决`menu-item组件`设置了`href属性`和`icon`后，折叠菜单导致图标变小，展开菜单，生成的`a标签`无法撑开全部宽度导致点击空白处无法正确跳转
2. 修改样式文件，在折叠状态下的`link`样式进行`display: none;`，正常状态下增加`flex: 1;`
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(menu): menu-item 设置href属性后的样式问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
