### PR TITLE
fix: 修复存在表格左边冻结列，往右边滚动时，hover表头出现边框后，表头冻结列和表格内容冻结列没有对齐问题

### DIFF
--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -1093,6 +1093,16 @@
       border-top: @border;
     }
   }
+
+  /** 表格左边有冻结列滚动时，去掉hover表头时多出的一个像素，避免出现表头的冻结列跟表内容的冻结列没有对齐的问题 */
+  &.@{prefix}-table__content--scrollable-to-left.@{prefix}-table__content--scrollable-to-right,
+  &.@{prefix}-table__content--scrollable-to-left {
+    thead.@{prefix}-table__header:hover {
+      .@{prefix}-table__cell--fixed-left-last:not(:last-child){
+        border-right: 0;
+      }
+    }
+  }
 }
 
 /** 可选中行的场景下，将 Checkbox 和 Radio 铺满整个单元格，增大点击范围，方便用户选中 */

--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -1098,7 +1098,7 @@
   &.@{prefix}-table__content--scrollable-to-left.@{prefix}-table__content--scrollable-to-right,
   &.@{prefix}-table__content--scrollable-to-left {
     thead.@{prefix}-table__header:hover {
-      .@{prefix}-table__cell--fixed-left-last:not(:last-child){
+      .@{prefix}-table__cell--fixed-left-last:not(:last-child) {
         border-right: 0;
       }
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
背景：存在表格左边冻结列，往右边滚动时，hover表头出现边框后，表头左边冻结列和表格内容左边冻结列没有对齐
<img width="655" alt="image" src="https://user-images.githubusercontent.com/16223845/224944775-5ec0ee9f-fe66-4014-8829-aaa9b789ded7.png">
解决方案：向右边滚动时，去掉左边最后冻结元素的右边框

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 修复存在表格左边冻结列，往右边滚动时，hover表头出现边框后，表头左边冻结列和表格内容左边冻结列没有对齐

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
