### PR TITLE
fix(image-viewer): esm下less会编译失败，需要转义less文件中min函数

### DIFF
--- a/style/web/components/image-viewer/_index.less
+++ b/style/web/components/image-viewer/_index.less
@@ -135,8 +135,8 @@
 
       .@{prefix}-image-viewer__modal-image {
         display: block;
-        max-width: min(90vw, 1000px);
-        max-height: min(90vh, 800px);
+        max-width: ~"min(90vw, 1000px)";
+        max-height: ~"min(90vh, 800px)";
         transition: all @anim-duration-base @anim-time-fn-easing;
         transform: rotate(0deg);
         object-fit: contain;
@@ -419,8 +419,8 @@
 }
 
 .@{prefix}-image-viewer-mini__content {
-  max-width: min(90vw, 1000px);
-  max-height: min(90vh, 800px);
+  max-width: ~"min(90vw, 1000px)";
+  max-height: ~"min(90vh, 800px)";
 
   .@{prefix}-image-viewer__modal-pic {
 
@@ -443,8 +443,8 @@
 
       .@{prefix}-image-viewer__modal-image {
         display: block;
-        max-width: min(80vw, 800px);
-        max-height: min(80vh, 600px);
+        max-width: ~"min(80vw, 800px)";
+        max-height: ~"min(80vh, 600px)";
         transition: all @anim-duration-base ease;
         transform: rotate(0deg);
         object-fit: contain;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

esm下less会编译失败，需要转义less文件中min函数
参考 https://lesscss.org/#escaping

### 📝 更新日志

无

- fix(image-viewer): 转义less文件中min函数

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
