### PR TITLE
fix: image default style

### DIFF
--- a/style/mobile/components/image/v2/_index.less
+++ b/style/mobile/components/image/v2/_index.less
@@ -8,6 +8,7 @@
 
   &__img {
     vertical-align: middle;
+    max-width: 100%;
   }
 
   &__mask {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<img width="1389" alt="image" src="https://github.com/Tencent/tdesign-common/assets/7600149/8f1c5ff1-eb02-4549-932e-930edc211fee">
Image 组件内没有设置 `max-width` 属性，官网上的样式依赖了单独引入的 reset 样式 https://github.com/Tencent/tdesign-common/blob/fix/image-default-style/style/mobile/_reset.less#L60。用户引入组件使用时会因为样式缺失，导致展示异常：

<img width="451" alt="image" src="https://github.com/Tencent/tdesign-common/assets/7600149/9be1308b-8f67-411b-8d0d-f16f8cd29ca8">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Image): 修复 Image 默认宽度样式缺失的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
