### PR TITLE
feat: remove useless menu style

### DIFF
--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -732,3 +732,15 @@ a.@{prefix}-menu__item {
     }
   }
 }
+
+.@{prefix}-is-head-menu {
+  .@{prefix}-menu__popup {
+    margin-top: calc((@menu-height-default - @head-menu-item-height) / 2) !important;
+  }
+}
+
+.@{prefix}-menu-is-nested {
+  .@{prefix}-menu__popup {
+    margin-top: calc(0px - @pop-padding-m) !important;
+  }
+}

--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -107,62 +107,8 @@ a.@{prefix}-menu__item {
     padding-left: 0;
   }
 
-  .@{prefix}-menu__popup {
-    top: calc(@head-menu-item-height + 12px);
-    left: 0;
-    min-width: 100%;
-    box-sizing: content-box;
-    transform-origin: center top;
-    border: solid .5px @menu-border-color;
-
-    .@{prefix}-menu__item {
-      display: flex;
-      align-items: center;
-      justify-content: flex-start;
-      white-space: nowrap;
-      padding-left: @comp-paddingLR-s;
-      padding-right: @comp-paddingLR-s;
-      min-width: 100%;
-      margin-left: 0;
-      color: @head-menu-popup-item-color;
-      box-sizing: border-box;
-
-      &.@{prefix}-is-active {
-        color: @menu-light-active-color;
-
-        .t-icon {
-          color: @menu-light-active-color;
-        }
-      }
-    }
-
-    li + li {
-      margin-top: @comp-margin-xxs;
-      margin-left: 0;
-    }
-  }
-
   .@{prefix}-fake-arrow {
     margin-left: @comp-margin-m;
-  }
-
-  // 多层情况
-  .@{prefix}-menu__popup-inner {
-    .@{prefix}-menu__popup {
-      top: -8px;
-      left: calc(100% + 16px);
-      transform-origin: left top;
-    }
-
-    .@{prefix}-menu__item {
-      text-align: left;
-      padding: 0 16px;
-      justify-content: space-between;
-    }
-
-    .@{prefix}-submenu-icon {
-      transform: rotate(270deg);
-    }
   }
 }
 
@@ -223,35 +169,9 @@ a.@{prefix}-menu__item {
       }
     }
 
-    .@{prefix}-menu__popup {
-      .@{prefix}-menu__item {
-        padding-left: @comp-paddingLR-s;
-        padding-right: @comp-paddingLR-s;
-        justify-content: flex-start;
-
-        span {
-          display: inline;
-        }
-
-        &.@{prefix}-menu__item--plain::after {
-          content: "";
-        }
-      }
-
-      .@{prefix}-fake-arrow {
-        display: block;
-      }
-    }
-
     .@{prefix}-submenu {
       &-icon {
         display: none;
-      }
-
-      .@{prefix}-menu__popup {
-        .@{prefix}-submenu-icon {
-          display: initial;
-        }
       }
 
       > .@{prefix}-menu__item {
@@ -428,19 +348,6 @@ a.@{prefix}-menu__item {
     }
   }
 
-  .@{prefix}-menu__popup {
-    top: 0;
-    left: calc(100% + @pop-padding-m);
-
-    .@{prefix}-menu__item, .@{prefix}-submenu {
-      margin: @comp-margin-xxs 0 0 0;
-
-      &:first-child {
-        margin-top: 0;
-      }
-    }
-  }
-
   &.@{prefix}-menu--dark {
     background: @menu-theme-dark;
 
@@ -473,20 +380,6 @@ a.@{prefix}-menu__item {
       &.@{prefix}-is-opened.@{prefix}-is-active {
         background-color: transparent;
       }
-    }
-
-    .@{prefix}-menu__popup {
-      background: @menu-theme-dark;
-
-      .@{prefix}-menu__item {
-        &.@{prefix}-is-active {
-          background-color: @default-menu-active-color--dark;
-        }
-      }
-    }
-
-    .@{prefix}-menu__popup {
-      background: @menu-theme-dark;
     }
 
     .@{prefix}-menu-group__title {
@@ -737,22 +630,13 @@ a.@{prefix}-menu__item {
   }
 
   &__popup {
-    max-height: 0;
     overflow: hidden;
-    transition: max-height @anim-duration-moderate @anim-time-fn-easing,
-      width @anim-duration-moderate @anim-time-fn-easing,
-      opacity @anim-duration-base linear;
     position: absolute;
     background: @menu-theme-light;
     z-index: @menu-outer-zindex;
     border-radius: @border-radius-medium;
     opacity: 0;
     .list-style-none();
-
-    // 超过 2 级的弹出菜单，不需要动画
-    .@{prefix}-menu__popup {
-      transition: none;
-    }
 
     &-wrapper {
       padding: @pop-padding-m;
@@ -766,24 +650,17 @@ a.@{prefix}-menu__item {
       margin-left: @comp-margin-s;
     }
 
+    .@{prefix}-menu__item {
+      padding-left: @comp-paddingLR-l;
+      padding-right: @comp-paddingLR-l;
+    }
+
     &.@{prefix}-is-vertical {
-      max-height: unset;
-      width: 0;
-
-      &.@{prefix}-is-opened {
-        width: var(--popup-width, 160px);
-      }
-
-      .@{prefix}-menu__item {
-        padding-left: @comp-paddingLR-l;
-        padding-right: @comp-paddingLR-l;
-      }
+      min-width: var(--popup-width, 160px);
     }
 
     &.@{prefix}-is-horizontal {
       .@{prefix}-menu__item {
-        padding-left: @comp-paddingLR-l;
-        padding-right: @comp-paddingLR-l;
         white-space: nowrap;
       }
 
@@ -793,28 +670,9 @@ a.@{prefix}-menu__item {
     }
 
     &.@{prefix}-is-opened {
-      max-height: calc(100vh - @menu-height-default * 2);
       opacity: 1;
       box-shadow: @menu-default-shadow;
       overflow: visible;
-
-      .@{prefix}-menu__popup {
-        top: calc(0px - @pop-padding-m);
-        left: 100%;
-        overflow-x: hidden;
-        overflow-y: auto;
-
-        &::before {
-          content: "";
-          display: block;
-          position: absolute;
-          left: -@horizontal-spacer;
-          width: @horizontal-spacer;
-          top: 0;
-          bottom: 0;
-        }
-        @horizontal-spacer: 16px;
-      }
     }
 
     .@{prefix}-menu__item {

--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -671,13 +671,8 @@ a.@{prefix}-menu__item {
   }
 
   &--dark {
-    &.@{prefix}-head-menu, &.@{prefix}-is-head {
+    &.@{prefix}-head-menu {
       background-color: @menu-theme-dark;
-
-      .@{prefix}-menu__popup {
-        background-color: @menu-theme-dark;
-        border: solid .5px @menu-border-color--dark;
-      }
     }
 
     .@{prefix}-menu__item {
@@ -709,6 +704,7 @@ a.@{prefix}-menu__item {
 
     .@{prefix}-menu__popup {
       background: @menu-theme-dark;
+      border: solid .5px @menu-border-color--dark;
 
       .@{prefix}-menu__item {
         color: @menu-item-color--dark;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
设计稿：
https://www.figma.com/file/KInDIZzoxifaKVQ3n5KB8W/branch/BTXgrqXUspoOc0FBFdvUM1/TDesign-for-web?type=design&node-id=95198-158233&t=m6YmJEESBlHze20A-0

修复次级弹出菜单内容未与父级菜单项对齐的问题，线上：

![image](https://github.com/Tencent/tdesign-common/assets/7600149/ef0895d4-f151-467c-bca9-3c566399945b)

修复后：
![image](https://github.com/Tencent/tdesign-common/assets/7600149/fd01f1be-447e-43e5-8fa4-c82f6afb2694)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Menu): 修复次级弹出菜单内容未与父级菜单项对齐的问题
- refact(Menu): React/Vue2/Vue next menu 使用 Popup 重构后，去除 common less 中已经无用的 Popup 样式
- chore(Menu): 原先各技术栈仓库中 js 实现的子菜单 inline 样式对齐实现方案，改为 `t-menu-is-nested` 样式类实现，方便通过全局 Design Token 方式调整尺寸和间距等

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
