### PR TITLE
fix(upload): 删除upload中对loading的颜色设置

### DIFF
--- a/style/web/components/upload/_index.less
+++ b/style/web/components/upload/_index.less
@@ -35,10 +35,6 @@
     color: @upload-icon-error-circle-filled-color;
   }
 
-  .@{prefix}-icon-loading {
-    color: @upload-icon-loading-color;
-  }
-
   .t-icon-time-filled {
     color: @upload-icon-time-filled-color;
   }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/2940
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
upload组件中对loading组件进行了额外的颜色设置，但设置的颜色与loading默认的颜色一致。故删除掉此颜色覆盖设置的css。不删除此css会对upload的slot中的组件样式造成影响，如slot传入的button使用了loading状态
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(upload): 删除upload中对loading的颜色设置

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
