### PR TITLE
fix: 数字为空时，应当返回 null，而不是 undefined

### DIFF
--- a/js/input-number/number.ts
+++ b/js/input-number/number.ts
@@ -54,7 +54,7 @@ export function putInRangeNumber(
     largeNumber?: boolean;
   }
 ) {
-  if (val === '') return undefined;
+  if (val === '') return null;
   const { max, min, lastValue, largeNumber } = params;
   if (!isInputNumber(val)) return lastValue;
   if (largeNumber && (isString(max) || max === Infinity) && (isString(min) || min === -Infinity)) {
@@ -241,7 +241,7 @@ export function formatUnCompleteNumber(
     isToFixed?: boolean;
   } = {}
 ): number | string {
-  if (['', null, undefined].includes(number) || !/\d+/.test(number)) return undefined;
+  if (['', null, undefined].includes(number) || !/\d+/.test(number)) return null;
   const { decimalPlaces, largeNumber, isToFixed } = extra;
   let newNumber = number.replace(/[.|+|\-|e]$/, '');
   if (largeNumber) {

--- a/test/unit/input-number/number.test.js
+++ b/test/unit/input-number/number.test.js
@@ -145,11 +145,11 @@ describe('canSetValue', () => {
 
 describe('formatUnCompleteNumber', () => {
   it('formatUnCompleteNumber: empty number', () => {
-    expect(formatUnCompleteNumber('-')).toBe(undefined);
-    expect(formatUnCompleteNumber('e')).toBe(undefined);
-    expect(formatUnCompleteNumber('')).toBe(undefined);
-    expect(formatUnCompleteNumber(undefined)).toBe(undefined);
-    expect(formatUnCompleteNumber(null)).toBe(undefined);
+    expect(formatUnCompleteNumber('-')).toBe(null);
+    expect(formatUnCompleteNumber('e')).toBe(null);
+    expect(formatUnCompleteNumber('')).toBe(null);
+    expect(formatUnCompleteNumber(undefined)).toBe(null);
+    expect(formatUnCompleteNumber(null)).toBe(null);
   });
 
   it('formatUnCompleteNumber: last unValid num', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
解决：https://github.com/Tencent/tdesign-vue-next/issues/2900
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: 数字为空时，应当返回 null，而不是 undefined

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
