### PR TITLE
fix: 解决 treeNodeModel 实例未能同步 node 属性的问题

### DIFF
--- a/js/tree/tree-node-model.ts
+++ b/js/tree/tree-node-model.ts
@@ -1,6 +1,5 @@
 import isUndefined from 'lodash/isUndefined';
 import isBoolean from 'lodash/isBoolean';
-import pick from 'lodash/pick';
 import omit from 'lodash/omit';
 import { TreeNode } from './tree-node';
 import { OptionData } from '../common';
@@ -9,232 +8,265 @@ import {
   TypeTreeNodeModel,
   TypeTreeNodeData,
   TypeTreeItem,
-  TreeNodeModelProps,
 } from './types';
 import log from '../log/log';
 
-// 获取节点需要暴露的属性
-function getExposedProps(node: TreeNode): TreeNodeModelProps {
-  const props = pick(node, [
-    'value',
-    'label',
-    'data',
-    'actived',
-    'expanded',
-    'checked',
-    'indeterminate',
-    'loading',
-  ]) as TreeNodeModelProps;
-  return props;
+export const nodeKey = '__tdesign_tree-node__';
+
+export class TreeNodeModel {
+  private [nodeKey]: TreeNode;
+
+  constructor(node: TreeNode) {
+    this[nodeKey] = node;
+  }
+
+  public get value() {
+    const node = this[nodeKey];
+    return node.value;
+  }
+
+  public get label() {
+    const node = this[nodeKey];
+    return node.label;
+  }
+
+  public get data() {
+    const node = this[nodeKey];
+    return node.data;
+  }
+
+  public get actived() {
+    const node = this[nodeKey];
+    return node.actived;
+  }
+
+  public get expanded() {
+    const node = this[nodeKey];
+    return node.expanded;
+  }
+
+  public get checked() {
+    const node = this[nodeKey];
+    return node.checked;
+  }
+
+  public get indeterminate() {
+    const node = this[nodeKey];
+    return node.indeterminate;
+  }
+
+  public get loading() {
+    const node = this[nodeKey];
+    return node.loading;
+  }
+
+  /**
+   * 获取节点所处层级
+   * @return number 节点层级序号
+   */
+  public getLevel() {
+    const node = this[nodeKey];
+    return node.getLevel();
+  }
+
+  /**
+   * 获取节点在父节点的子节点列表中的位置
+   * - 如果没有父节点，则获取节点在根节点列表的位置
+   * @return number 节点位置序号
+   */
+  public getIndex() {
+    const node = this[nodeKey];
+    return node.getIndex();
+  }
+
+  /**
+   * 是否为兄弟节点中的第一个节点
+   * @return boolean 是否为第一个节点
+   */
+  public isFirst() {
+    const node = this[nodeKey];
+    return node.isFirst();
+  }
+
+  /**
+   * 是否为兄弟节点中的最后一个节点
+   * @return boolean 是否为最后一个节点
+   */
+  public isLast() {
+    const node = this[nodeKey];
+    return node.isLast();
+  }
+
+  /**
+   * 是否为叶子节点，叶子节点没有子节点
+   * @return boolean 是否为叶子节点
+   */
+  public isLeaf() {
+    const node = this[nodeKey];
+    return node.isLeaf();
+  }
+
+  /**
+   * 在当前节点之前插入节点
+   * @param {object} newData 要插入的节点或者数据
+   * @return void
+   */
+  public insertBefore(newData: TypeTreeItem) {
+    const node = this[nodeKey];
+    return node.insertBefore(newData);
+  }
+
+  /**
+   * 在当前节点之后插入节点
+   * @param {object} newData 要插入的节点或者数据
+   * @return void
+   */
+  public insertAfter(newData: TypeTreeItem) {
+    const node = this[nodeKey];
+    return node.insertAfter(newData);
+  }
+
+  /**
+   * 追加节点数据
+   * @param {object | object[]} data 节点数据
+   * @return void
+   */
+  public appendData(data: TypeTreeNodeData | TypeTreeNodeData[]) {
+    const node = this[nodeKey];
+    return node.append(data);
+  }
+
+  /**
+   * 返回路径节点
+   * - 路径节点包含自己在内
+   * - 节点顺序与父级节点顺序相反，从根到当前
+   * @return TreeNodeModel[] 路径节点数组
+   */
+  public getPath(): TypeTreeNodeModel[] {
+    const node = this[nodeKey];
+    const nodes = node.getPath();
+    return nodes.map((item: TreeNode) => item.getModel());
+  }
+
+  /**
+   * 获取本节点的父节点
+   * @return TreeNodeModel 父节点
+   */
+  public getParent(): TypeTreeNodeModel {
+    const node = this[nodeKey];
+    return node.parent?.getModel();
+  }
+
+  /**
+   * 获取所有父级节点
+   * - 顺序为从当前到根
+   * @return TreeNodeModel[] 父级节点数组
+   */
+  public getParents(): TypeTreeNodeModel[] {
+    const node = this[nodeKey];
+    const nodes = node.getParents();
+    return nodes.map((item: TreeNode) => item.getModel());
+  }
+
+  /**
+   * 获取本节点的根节点
+   * @return TreeNodeModel 根节点
+   */
+  public getRoot(): TypeTreeNodeModel {
+    const node = this[nodeKey];
+    const root = node.getRoot();
+    return root?.getModel();
+  }
+
+  /**
+   * 获取所有兄弟节点，包含自己在内
+   * @return TreeNodeModel[] 兄弟节点数组
+   */
+  public getSiblings(): TypeTreeNodeModel[] {
+    const node = this[nodeKey];
+    const nodes = node.getSiblings();
+    return nodes.map((item: TreeNode) => item.getModel());
+  }
+
+  /**
+   * 获取当前节点的子节点
+   * @param {boolean} deep 是否获取所有深层子节点
+   * @return TreeNodeModel[] 子节点数组
+   */
+  public getChildren(deep?: boolean): boolean | TypeTreeNodeModel[] {
+    const node = this[nodeKey];
+    let childrenModel: boolean | TypeTreeNodeModel[] = false;
+    const { children } = node;
+    if (Array.isArray(children)) {
+      if (children.length > 0) {
+        if (deep) {
+          const nodes = node.walk();
+          nodes.shift();
+          childrenModel = nodes.map((item) => item.getModel());
+        } else {
+          childrenModel = children.map((item) => item.getModel());
+        }
+      } else {
+        childrenModel = false;
+      }
+    } else if (isBoolean(children)) {
+      childrenModel = children;
+    }
+    return childrenModel;
+  }
+
+  /**
+   * 移除节点
+   * - 提供 value 参数，移除本节点子节点中的节点
+   * - 不提供 value 参数，移除自己
+   * @param {string} value 目标节点值
+   * @return void
+   */
+  public remove(value?: TreeNodeValue) {
+    const node = this[nodeKey];
+    if (!value) {
+      node.remove();
+      return;
+    }
+
+    const { tree } = node;
+    const targetNode = tree.getNode(value);
+    if (!targetNode) {
+      log.warnOnce('Tree', `\`${value}\` is not exist`);
+      return;
+    }
+
+    const parents = targetNode.getParents();
+    const parentValues = parents.map((pnode) => (pnode.value));
+    if (parentValues.indexOf(node.value) < 0) {
+      log.warnOnce('Tree', `\`${value}\` is not a childNode of current node`);
+      return;
+    }
+    targetNode.remove();
+  }
+
+  /**
+   * 设置本节点携带的元数据
+   * @param {object} data 节点数据
+   * @return void
+   */
+  public setData(data: OptionData) {
+    const node = this[nodeKey];
+    // 详细细节可见 https://github.com/Tencent/tdesign-common/issues/655
+    const _data = omit(data, ['children', 'value', 'label']);
+    const { keys } = node.tree.config;
+    const dataValue = data[keys?.value || 'value'];
+    const dataLabel = data[keys?.label || 'label'];
+    if (!isUndefined(dataValue)) _data.value = dataValue;
+    if (!isUndefined(dataLabel)) _data.label = dataLabel;
+
+    Object.assign(node.data, _data);
+    Object.assign(node, _data);
+  }
 }
 
 // 封装对外暴露的对象
 export function createNodeModel(node: TreeNode): TypeTreeNodeModel {
-  const props = getExposedProps(node);
-
-  const model: TypeTreeNodeModel = {
-    ...props,
-
-    /**
-     * 获取节点所处层级
-     * @return number 节点层级序号
-     */
-    getLevel() {
-      return node.getLevel();
-    },
-
-    /**
-     * 获取节点在父节点的子节点列表中的位置
-     * - 如果没有父节点，则获取节点在根节点列表的位置
-     * @return number 节点位置序号
-     */
-    getIndex() {
-      return node.getIndex();
-    },
-
-    /**
-     * 是否为兄弟节点中的第一个节点
-     * @return boolean 是否为第一个节点
-     */
-    isFirst() {
-      return node.isFirst();
-    },
-
-    /**
-     * 是否为兄弟节点中的最后一个节点
-     * @return boolean 是否为最后一个节点
-     */
-    isLast() {
-      return node.isLast();
-    },
-
-    /**
-     * 是否为叶子节点，叶子节点没有子节点
-     * @return boolean 是否为叶子节点
-     */
-    isLeaf() {
-      return node.isLeaf();
-    },
-
-    /**
-     * 在当前节点之前插入节点
-     * @param {object} newData 要插入的节点或者数据
-     * @return void
-     */
-    insertBefore(newData: TypeTreeItem) {
-      return node.insertBefore(newData);
-    },
-
-    /**
-     * 在当前节点之后插入节点
-     * @param {object} newData 要插入的节点或者数据
-     * @return void
-     */
-    insertAfter(newData: TypeTreeItem) {
-      return node.insertAfter(newData);
-    },
-
-    /**
-     * 追加节点数据
-     * @param {object | object[]} data 节点数据
-     * @return void
-     */
-    appendData(data: TypeTreeNodeData | TypeTreeNodeData[]) {
-      return node.append(data);
-    },
-
-    /**
-     * 返回路径节点
-     * - 路径节点包含自己在内
-     * - 节点顺序与父级节点顺序相反，从根到当前
-     * @return TreeNodeModel[] 路径节点数组
-     */
-    getPath(): TypeTreeNodeModel[] {
-      const nodes = node.getPath();
-      return nodes.map((item: TreeNode) => item.getModel());
-    },
-
-    /**
-     * 获取本节点的父节点
-     * @return TreeNodeModel 父节点
-     */
-    getParent(): TypeTreeNodeModel {
-      return node.parent?.getModel();
-    },
-
-    /**
-     * 获取所有父级节点
-     * - 顺序为从当前到根
-     * @return TreeNodeModel[] 父级节点数组
-     */
-    getParents(): TypeTreeNodeModel[] {
-      const nodes = node.getParents();
-      return nodes.map((item: TreeNode) => item.getModel());
-    },
-
-    /**
-     * 获取本节点的根节点
-     * @return TreeNodeModel 根节点
-     */
-    getRoot(): TypeTreeNodeModel {
-      const root = node.getRoot();
-      return root?.getModel();
-    },
-
-    /**
-     * 获取所有兄弟节点，包含自己在内
-     * @return TreeNodeModel[] 兄弟节点数组
-     */
-    getSiblings(): TypeTreeNodeModel[] {
-      const nodes = node.getSiblings();
-      return nodes.map((item: TreeNode) => item.getModel());
-    },
-
-    /**
-     * 获取当前节点的子节点
-     * @param {boolean} deep 是否获取所有深层子节点
-     * @return TreeNodeModel[] 子节点数组
-     */
-    getChildren(deep?: boolean): boolean | TypeTreeNodeModel[] {
-      let childrenModel: boolean | TypeTreeNodeModel[] = false;
-      const { children } = node;
-      if (Array.isArray(children)) {
-        if (children.length > 0) {
-          if (deep) {
-            const nodes = node.walk();
-            nodes.shift();
-            childrenModel = nodes.map((item) => item.getModel());
-          } else {
-            childrenModel = children.map((item) => item.getModel());
-          }
-        } else {
-          childrenModel = false;
-        }
-      } else if (isBoolean(children)) {
-        childrenModel = children;
-      }
-      return childrenModel;
-    },
-
-    /**
-     * 移除节点
-     * - 提供 value 参数，移除本节点子节点中的节点
-     * - 不提供 value 参数，移除自己
-     * @param {string} value 目标节点值
-     * @return void
-     */
-    remove(value?: TreeNodeValue) {
-      if (!value) {
-        node.remove();
-        return;
-      }
-
-      const { tree } = node;
-      const targetNode = tree.getNode(value);
-      if (!targetNode) {
-        log.warnOnce('Tree', `\`${value}\` is not exist`);
-        return;
-      }
-
-      const parents = targetNode.getParents();
-      const parentValues = parents.map((pnode) => (pnode.value));
-      if (parentValues.indexOf(node.value) < 0) {
-        log.warnOnce('Tree', `\`${value}\` is not a childNode of current node`);
-        return;
-      }
-      targetNode.remove();
-    },
-
-    /**
-     * 设置本节点携带的元数据
-     * @param {object} data 节点数据
-     * @return void
-     */
-    setData(data: OptionData) {
-      // 详细细节可见 https://github.com/Tencent/tdesign-common/issues/655
-      const _data = omit(data, ['children', 'value', 'label']);
-      const { keys } = node.tree.config;
-      const dataValue = data[keys?.value || 'value'];
-      const dataLabel = data[keys?.label || 'label'];
-      if (!isUndefined(dataValue)) _data.value = dataValue;
-      if (!isUndefined(dataLabel)) _data.label = dataLabel;
-
-      Object.assign(node.data, _data);
-      Object.assign(node, _data);
-    },
-  };
-
-  return model;
-}
-
-/**
- * 同步节点属性到封装对象
- * @param {TreeNodeModel} 节点封装对象
- * @param {object} data 节点数据
- * @return void
- */
-export function updateNodeModel(model: TypeTreeNodeModel, node: TreeNode) {
-  // 同步节点属性
-  const props = getExposedProps(node);
-  Object.assign(model, props);
+  const model = new TreeNodeModel(node);
+  return model as TypeTreeNodeModel;
 }

--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -16,7 +16,6 @@ import {
 } from './types';
 import {
   createNodeModel,
-  updateNodeModel,
 } from './tree-node-model';
 import log from '../log';
 
@@ -1302,7 +1301,6 @@ export class TreeNode {
       model = createNodeModel(this);
       this.model = model;
     }
-    updateNodeModel(model, this);
     return model;
   }
 }

--- a/js/tree/tree-store.ts
+++ b/js/tree/tree-store.ts
@@ -11,7 +11,6 @@ import { TreeNode } from './tree-node';
 import {
   TreeNodeValue,
   TypeIdMap,
-  TypeTimer,
   TypeTargetNode,
   TypeTreeNodeData,
   TypeTreeItem,

--- a/js/tree/tree-store.ts
+++ b/js/tree/tree-store.ts
@@ -472,20 +472,6 @@ export class TreeStore {
   }
 
   /**
-   * 更新所有树节点状态
-   * @return void
-   */
-  public refreshState(): void {
-    const { nodeMap } = this;
-    // 树在初始化未回流时，nodes 数组为空
-    // 所以遍历 nodeMap 确保初始化阶段 refreshState 方法也可以触发全部节点的更新
-    nodeMap.forEach((node) => {
-      node.update();
-      node.updateChecked();
-    });
-  }
-
-  /**
    * 标记节点重排
    * - 应该仅在树节点增删改查时调用
    * - 节点重排会在延时后触发 refreshNodes 方法的调用
@@ -794,11 +780,26 @@ export class TreeStore {
   }
 
   /**
+   * 更新所有树节点状态，但不更新选中态
+   * 用于不影响选中态时候的更新，减少递归循环造成的时间消耗
+   * @return void
+   */
+  public refreshState(): void {
+    const { nodeMap } = this;
+    // 树在初始化未回流时，nodes 数组为空
+    // 所以遍历 nodeMap 确保初始化阶段 refreshState 方法也可以触发全部节点的更新
+    nodeMap.forEach((node) => {
+      node.update();
+    });
+  }
+
+  /**
    * 更新全部节点状态
    * @return void
    */
   public updateAll(): void {
-    this.nodeMap.forEach((node) => {
+    const { nodeMap } = this;
+    nodeMap.forEach((node) => {
       node.update();
       node.updateChecked();
     });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

解决 treeNodeModel 实例未能同步 node 属性的问题。
进行了小幅度的性能改进。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题: treeNodeModel 实例未能同步 node 属性，取得 treeNodeModel 之后，如果更改了 treeNode 的状态，读取原 treeNodeModel 实例的 visible, checked 等属性时，拿到的还是之前取值时的状态。

解决方式: 这类属性改为使用 public get 方式定义，变为取值方式，可确保之后即使用户自行缓存了 treeNodeModel 节点，也能拿到同步的属性。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree): 解决 treeNodeModel 实例未能同步 node 属性的问题
- refactor(tree): 用 nextTick 机制替换了 timeout 延时，来检查 tree 结构，并触发更新事件。
- perf(tree): 设置 store 选项时，仅更新节点状态，不更新节点选中态，减少计算量。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- ☑️ 文档已补充或无须补充
- ☑️ 代码演示已提供或无须提供
- ☑️ TypeScript 定义已补充或无须补充
- ☑️ Changelog 已提供或无须提供
