### PR TITLE
Revert "fix: 数字为空时，应当返回 null，而不是 undefined"

### DIFF
--- a/js/input-number/number.ts
+++ b/js/input-number/number.ts
@@ -54,7 +54,7 @@ export function putInRangeNumber(
     largeNumber?: boolean;
   }
 ) {
-  if (val === '') return null;
+  if (val === '') return undefined;
   const { max, min, lastValue, largeNumber } = params;
   if (!isInputNumber(val)) return lastValue;
   if (largeNumber && (isString(max) || max === Infinity) && (isString(min) || min === -Infinity)) {
@@ -241,7 +241,7 @@ export function formatUnCompleteNumber(
     isToFixed?: boolean;
   } = {}
 ): number | string {
-  if (['', null, undefined].includes(number) || !/\d+/.test(number)) return null;
+  if (['', null, undefined].includes(number) || !/\d+/.test(number)) return undefined;
   const { decimalPlaces, largeNumber, isToFixed } = extra;
   let newNumber = number.replace(/[.|+|\-|e]$/, '');
   if (largeNumber) {

--- a/test/unit/input-number/number.test.js
+++ b/test/unit/input-number/number.test.js
@@ -145,11 +145,11 @@ describe('canSetValue', () => {
 
 describe('formatUnCompleteNumber', () => {
   it('formatUnCompleteNumber: empty number', () => {
-    expect(formatUnCompleteNumber('-')).toBe(null);
-    expect(formatUnCompleteNumber('e')).toBe(null);
-    expect(formatUnCompleteNumber('')).toBe(null);
-    expect(formatUnCompleteNumber(undefined)).toBe(null);
-    expect(formatUnCompleteNumber(null)).toBe(null);
+    expect(formatUnCompleteNumber('-')).toBe(undefined);
+    expect(formatUnCompleteNumber('e')).toBe(undefined);
+    expect(formatUnCompleteNumber('')).toBe(undefined);
+    expect(formatUnCompleteNumber(undefined)).toBe(undefined);
+    expect(formatUnCompleteNumber(null)).toBe(undefined);
   });
 
   it('formatUnCompleteNumber: last unValid num', () => {


### PR DESCRIPTION
Reverts Tencent/tdesign-common#1530

问题在tdesign-vue-next 1.3.6版本已修复 为保证组件空值一致为undefined revert这次改动