### PR TITLE
[WIP]refactor: Link underline refactor by text-decoration

### DIFF
--- a/style/web/components/link/_index.less
+++ b/style/web/components/link/_index.less
@@ -16,58 +16,23 @@
     color: @@theme-active;
   }
   // hover - underline
-  &.@{prefix}-link--hover-underline {
-    &::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      right: 0;
-      height: 0;
-      bottom: 0;
-      border-bottom: 1px solid @@theme-default;
-      // 下划线动画
-      opacity: 0;
-      transition: all @anim-duration-base linear;
-    }
-
-    &:hover::after {
-      opacity: 1;
-    }
-
-    &:active::after {
-      opacity: 1;
-      border-color: @@theme-active;
-    }
+  &.@{prefix}-link--hover-underline:hover {
+    text-decoration: underline;
+    // 应与图标和文字的间距相同
+    text-underline-offset: @comp-margin-xs;
+  }
+  &.@{prefix}-is-underline {
+    text-decoration: underline;
+    text-underline-offset: @comp-margin-xs;
   }
   // hover - color
   &.@{prefix}-link--hover-color {
     &:hover {
       color: @@theme-hover;
     }
-    // 下划线场景 hover active时 需要改动颜色
-    &.@{prefix}-is-underline:hover::after {
-      border-color: @@theme-hover;
-    }
-    &.@{prefix}-is-underline:active::after {
-      border-color: @@theme-active;
-    }
 
     &:active {
       color: @@theme-active;
-    }
-  }
-  // 下划线样式 优先级高于 t-link--hover-underline 需要放在后面 否则opacity 被覆盖 无法显示下划线
-  &.@{prefix}-is-underline {
-    &::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      right: 0;
-      height: 0;
-      bottom: 0;
-      opacity: 1;
-      border-bottom: 1px solid @@theme-default;
-      transition: all @anim-duration-base linear;
     }
   }
   // 禁用样式 优先级最高 所以放在最后
@@ -78,9 +43,6 @@
     &:hover,
     &:active {
       color: @@theme-disabled;
-    }
-    &.@{prefix}-is-underline::after {
-      border-color: @@theme-disabled;
     }
   }
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

更改 Link 下划线实现方式，由 `::after` 伪元素改为 `text-decoration` 以满足如下换行使用场景
![image](https://github.com/Tencent/tdesign-vue/assets/7600149/29e42d5c-88e2-4778-a2f7-37efe7917e67)

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refact(Link): 更改 Link 下划线实现方式，由 `::after` 伪元素改为 `text-decoration` 以满足换行使用场景

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
