### PR TITLE
fix(cascader): 修复没有prop.title没有绑定关闭按钮错位问题 (#1086)

### DIFF
--- a/style/mobile/components/cascader/v2/_index.less
+++ b/style/mobile/components/cascader/v2/_index.less
@@ -24,6 +24,7 @@
     font-weight: 700;
     text-align: center;
     line-height: 48px;
+    height: 48px;
     font-size: @cascder-title-font-size;
   }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-mobile-vue/issues/1086

### 💡 需求背景和解决方案


### 📝 更新日志


- fix(cascader): 未传入title，关闭按钮样式错位

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
