### PR TITLE
fix(radio-button):  表单验证提示场景下，右边框颜色不一致

### DIFF
--- a/style/web/components/form/_mixin.less
+++ b/style/web/components/form/_mixin.less
@@ -36,7 +36,7 @@
 
       .@{prefix}-radio-button {
         &:last-child {
-          border-color: @@borderColor;
+          border-right-color: @@borderColor;
           @borderColor: "input-border-color-@{status}";
         }
       }

--- a/style/web/components/form/_mixin.less
+++ b/style/web/components/form/_mixin.less
@@ -34,6 +34,13 @@
         }
       }
 
+      .@{prefix}-radio-button {
+        &:last-child {
+          border-color: @@borderColor;
+          @borderColor: "input-border-color-@{status}";
+        }
+      }
+
       .@{prefix}-textarea__inner {
         &.@{prefix}-is-focused {
           box-shadow: 0 0 0 2px @@boxShadowColor;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
修复前
<img width="615" alt="image" src="https://github.com/Tencent/tdesign-common/assets/10710889/535857bd-ab9b-4b2f-9555-a266ed5206ed">

修复后
<img width="478" alt="image" src="https://github.com/Tencent/tdesign-common/assets/10710889/6a7ebe7c-fb97-4a6d-b56e-b7190776db52">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(radio-button):  右边框颜色不一致

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

