### PR TITLE
feat(Menu): update divider & margin style

### DIFF
--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -60,7 +60,6 @@ a.@{prefix}-menu__item {
     flex: 1;
     display: flex;
     align-items: center;
-    // overflow: auto hidden;
   }
 
   .@{prefix}-menu__operations {
@@ -136,6 +135,12 @@ a.@{prefix}-menu__item {
   &.@{prefix}-is-collapsed {
     width: @default-menu-collapse-width;
 
+    .@{prefix}-menu__logo {
+      & > * {
+        margin-left: @comp-margin-l;
+      }
+    }
+
     .@{prefix}-menu {
       .@{prefix}-menu__item {
         padding: 0 14px;
@@ -202,6 +207,18 @@ a.@{prefix}-menu__item {
       }
     }
 
+    .@{prefix}-menu-group {
+      &:first-child {
+        .@{prefix}-menu-group__title {
+          display: none;
+
+          & + * {
+            margin-top: 0;
+          }
+        }
+      }
+    }
+
     .@{prefix}-menu-group__title {
       padding: 0;
       font-size: 0;
@@ -249,7 +266,6 @@ a.@{prefix}-menu__item {
     .@{prefix}-menu {
       padding: @comp-paddingTB-l @comp-paddingLR-s;
       position: relative;
-      // overflow: hidden auto;
       flex: 1;
 
       &--scroll {
@@ -257,6 +273,20 @@ a.@{prefix}-menu__item {
 
         overflow-y: auto;
         overflow-x: hidden;
+      }
+
+      & > *:not(.@{prefix}-menu-group) {
+        &:not(:first-child) {
+          margin-top: @comp-margin-xs;
+        }
+      }
+
+      .@{prefix}-menu-group,
+      .@{prefix}-menu__sub,
+      .@{prefix}-submenu {
+        & > *:not(:first-child) {
+          margin-top: @comp-margin-xs;
+        }
       }
     }
 
@@ -273,7 +303,6 @@ a.@{prefix}-menu__item {
   }
 
   .@{prefix}-submenu {
-    margin-bottom: @comp-margin-xs;
     position: relative;
   }
 
@@ -301,7 +330,6 @@ a.@{prefix}-menu__item {
 
   .@{prefix}-menu__item {
     &.@{prefix}-is-opened {
-      margin: @comp-margin-xs 0;
       color: @menu-color-light;
       background-color: unset;
 
@@ -328,7 +356,6 @@ a.@{prefix}-menu__item {
 
   .@{prefix}-menu__item {
     position: relative;
-    margin: @comp-margin-xs 0;
     padding: 0 10px 0 16px;
     height: @default-menu-item-height;
     line-height: @default-menu-item-height;
@@ -338,14 +365,6 @@ a.@{prefix}-menu__item {
     transition: background-color @anim-duration-slow @anim-time-fn-easing,
       padding @anim-duration-slow @anim-time-fn-easing;
     box-sizing: border-box;
-
-    &:first-child {
-      margin-top: 0;
-    }
-
-    &:last-child {
-      margin-bottom: 0;
-    }
 
     .t-icon {
       width: 20px;
@@ -759,10 +778,8 @@ a.@{prefix}-menu__item {
 
   .@{prefix}-menu__item,
   .@{prefix}-submenu {
-    margin: @comp-margin-xxs 0 0 0;
-
-    &:first-child {
-      margin-top: 0;
+    &:not(:first-child) {
+      margin-top: @comp-margin-xxs;
     }
   }
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/3533
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 隐藏 可分组的侧边导航 收起样式的第一个分隔符
 2. 优化 可分组的侧边导航 收起时 logo 的 margin 样式，左边距从 xxl 改为 l
 3. 优化侧边导航 margin 的实现方式，使用 `not first-child` 实现

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Menu): 优化`Menu`侧边导航的样式，隐藏收起后的第一条分隔线

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
