### PR TITLE
feat: support space style in old browsers

### DIFF
--- a/js/utils/helper.ts
+++ b/js/utils/helper.ts
@@ -106,7 +106,7 @@ export function getFlexGapPolyFill() {
   if (typeof navigator === 'undefined' || !navigator) return false;
   const ua = navigator.userAgent;
   const chromeMatch = ua.match(/AppleWebKit.+Chrome\/(.+) Safari\/.+/i);
-  if (Number(chromeMatch?.[1]?.split('.')[0]) < 180) return true;
+  if (Number(chromeMatch?.[1]?.split('.')[0]) < 100) return true;
   const safariMatch = ua.match(/AppleWebKit.+Version\/(.+) Safari\/.+/i);
   if (Number(safariMatch?.[1]?.split('.')[0]) < 12) return true;
   const ieVersion = getIEVersion();

--- a/js/utils/helper.ts
+++ b/js/utils/helper.ts
@@ -95,6 +95,28 @@ export function getIEVersion() {
 }
 
 /**
+ * Safari Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15
+ * FireFox Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/114.0
+ * Chrome Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36
+ * Chrome 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.3
+ * 搜狗 Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36 SE 2.X MetaSr 1.
+ * 360 Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.9 Safari/537.36 QIHU 360EE
+ */
+export function getFlexGapPolyFill() {
+  if (typeof navigator === 'undefined' || !navigator) return false;
+  const ua = navigator.userAgent;
+  const chromeMatch = ua.match(/AppleWebKit.+Chrome\/(.+) Safari\/.+/i);
+  if (Number(chromeMatch?.[1]?.split('.')[0]) < 180) return true;
+  const safariMatch = ua.match(/AppleWebKit.+Version\/(.+) Safari\/.+/i);
+  if (Number(safariMatch?.[1]?.split('.')[0]) < 12) return true;
+  const ieVersion = getIEVersion();
+  if (ieVersion <= 11) return true;
+  const fireFoxMatch = ua.match(/Firefox\/(.+)/i);
+  if (Number(fireFoxMatch?.[1]?.split('.')[0]) < 100) return true;
+  return false;
+}
+
+/**
  * 计算字符串字符的长度并可以截取字符串。
  * @param str 传入字符串
  * @param maxCharacter 规定最大字符串长度

--- a/style/web/components/space/_index.less
+++ b/style/web/components/space/_index.less
@@ -41,12 +41,25 @@
 .@{prefix}-space {
   &.@{prefix}-space--polyfill {
     display: flex;
-    margin-left: calc(-1 * var(--column-gap, 0));
-    margin-top: calc(-1 * var(--row-gap, 0));
+
+    &.@{prefix}-space-horizontal,
+    &.@{prefix}-space--break-line {
+      margin-left: calc(-1 * var(--column-gap, 0));
+    }
+
+    &.@{prefix}-space-vertical,
+    &.@{prefix}-space--break-line {
+      margin-top: calc(-1 * var(--row-gap, 0));
+    }
   }
 
-  &.@{prefix}-space--polyfill > * {
+  &.@{prefix}-space--polyfill.@{prefix}-space-horizontal > *,
+  &.@{prefix}-space--polyfill.@{prefix}-space--break-line > * {
     margin-left: var(--column-gap);
+  }
+
+  &.@{prefix}-space--polyfill.@{prefix}-space-vertical > *,
+  &.@{prefix}-space--polyfill.@{prefix}-space--break-line > * {
     margin-top: var(--row-gap);
   }
 }

--- a/style/web/components/space/_index.less
+++ b/style/web/components/space/_index.less
@@ -33,3 +33,20 @@
     }
   }
 }
+
+.@{prefix}-space.@{prefix}-space--break-line {
+  flex-wrap: wrap;
+}
+
+.@{prefix}-space {
+  &.@{prefix}-space--polyfill {
+    display: flex;
+    margin-left: calc(-1 * var(--column-gap, 0));
+    margin-top: calc(-1 * var(--row-gap, 0));
+  }
+
+  &.@{prefix}-space--polyfill > * {
+    margin-left: var(--column-gap);
+    margin-top: var(--row-gap);
+  }
+}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Space): 支持老旧浏览器也能正常显示子元素之间的间距，[tdesign-vue#1901](https://github.com/Tencent/tdesign-vue/issues/1901)

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
