### PR TITLE
feat(Upload): 文件列表支持显示上传失败的原因

### DIFF
--- a/js/upload/main.ts
+++ b/js/upload/main.ts
@@ -76,7 +76,6 @@ export function handleError(options: OnErrorParams) {
     file.status = 'fail';
     file.response = res;
   });
-  
   return { response: res, event, files, XMLHttpRequest };
 }
 
@@ -149,7 +148,7 @@ export function uploadOneRequest(params: HandleUploadParams): Promise<UploadRequ
           resolve({});
           return;
         }
-        let response = res.response as ResponseType;
+        let response = (res.response || {}) as ResponseType;
         if (isFunction(params.formatResponse)) {
           response = params.formatResponse(response, { file: toUploadFiles[0], currentFiles: toUploadFiles });
           if (response.status === 'success' && !response.files) {

--- a/js/upload/main.ts
+++ b/js/upload/main.ts
@@ -15,6 +15,7 @@ import {
   handleSuccessParams,
   UploadTriggerUploadText,
   ErrorContext,
+  ResponseType,
 } from './types';
 
 export interface BeforeUploadExtra {
@@ -67,13 +68,15 @@ export interface OnErrorParams extends ErrorContext {
 
 export function handleError(options: OnErrorParams) {
   const { event, files, response, XMLHttpRequest, formatResponse } = options;
-  files.forEach((file) => {
-    file.status = 'fail';
-  });
   let res = response;
   if (isFunction(formatResponse)) {
     res = formatResponse(response, { file: files[0], currentFiles: files });
   }
+  files.forEach((file) => {
+    file.status = 'fail';
+    file.response = res;
+  });
+  
   return { response: res, event, files, XMLHttpRequest };
 }
 
@@ -146,7 +149,15 @@ export function uploadOneRequest(params: HandleUploadParams): Promise<UploadRequ
           resolve({});
           return;
         }
-        const { response = {} } = res;
+        let response = res.response as ResponseType;
+        if (isFunction(params.formatResponse)) {
+          response = params.formatResponse(response, { file: toUploadFiles[0], currentFiles: toUploadFiles });
+          if (response.status === 'success' && !response.files) {
+            log.error('Upload', 'formatResponse:: upload success `files` are missing');
+          } else if (!response.status) {
+            log.error('Upload', 'formatResponse: return value of `status` is missing');
+          }
+        }
         if (res.status === 'fail') {
           response.error = res.error || response.error;
         }

--- a/js/upload/types.ts
+++ b/js/upload/types.ts
@@ -182,7 +182,7 @@ export interface OnResponseErrorContext {
   files: UploadFile[];
 }
 
-export type ResponseType = { error?: string; url?: string } & Record<string, any>;
+export type ResponseType = { error?: string; url?: string; status?: 'fail' | 'success'; files?: UploadFile[] } & Record<string, any>
 
 export interface HandleUploadParams {
   /** 已经上传过的文件 */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Upload): 批量文件上传支持在列表中显示上传失败的原因

<img width="812" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/11605702/059e2132-1856-4086-bcbf-288ad3039b5d">
- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
