### PR TITLE
fix(tree): tree 节点禁用状态逻辑改进

### DIFF
--- a/js/tree/tree-node-model.ts
+++ b/js/tree/tree-node-model.ts
@@ -258,6 +258,8 @@ export class TreeNodeModel {
    */
   public setData(data: OptionData) {
     const node = this[nodeKey];
+    // syncAttrs 列举的属性，key 名称可被 tree.config.keys 定义
+    // 因此同步状态时需要读取被定义的 key 名称
     // 详细细节可见 https://github.com/Tencent/tdesign-common/issues/655
     const syncAttrs = [
       'value',
@@ -267,8 +269,8 @@ export class TreeNodeModel {
     const cleanData = omit(data, ['children', ...syncAttrs]);
     const { keys } = node.tree.config;
     syncAttrs.forEach((attr: string) => {
-      const dataAttr = get(data, keys?.[attr] || attr);
-      if (!isUndefined(dataAttr)) cleanData[attr] = dataAttr;
+      const dataAttrValue = get(data, keys?.[attr] || attr);
+      if (!isUndefined(dataAttrValue)) cleanData[attr] = dataAttrValue;
     });
     Object.assign(node.data, cleanData);
     Object.assign(node, cleanData);

--- a/js/tree/tree-node-model.ts
+++ b/js/tree/tree-node-model.ts
@@ -61,6 +61,11 @@ export class TreeNodeModel {
     return node.loading;
   }
 
+  public get disabled() {
+    const node = this[nodeKey];
+    return node.isDisabled();
+  }
+
   /**
    * 获取节点所处层级
    * @return number 节点层级序号
@@ -254,16 +259,19 @@ export class TreeNodeModel {
   public setData(data: OptionData) {
     const node = this[nodeKey];
     // 详细细节可见 https://github.com/Tencent/tdesign-common/issues/655
-    const _data = omit(data, ['children', 'value', 'label', 'disabled']);
+    const syncAttrs = [
+      'value',
+      'label',
+      'disabled',
+    ];
+    const cleanData = omit(data, ['children', ...syncAttrs]);
     const { keys } = node.tree.config;
-    const dataValue = get(data, keys?.value || 'value');
-    const dataLabel = get(data, keys?.label || 'label');
-    const dataDisabled = get(data, keys?.disabled || 'disabled');
-    if (!isUndefined(dataValue)) _data.value = dataValue;
-    if (!isUndefined(dataLabel)) _data.label = dataLabel;
-    if (!isUndefined(dataDisabled)) _data.disable = dataDisabled;
-    Object.assign(node.data, _data);
-    Object.assign(node, _data);
+    syncAttrs.forEach((attr: string) => {
+      const dataAttr = get(data, keys?.[attr] || attr);
+      if (!isUndefined(dataAttr)) cleanData[attr] = dataAttr;
+    });
+    Object.assign(node.data, cleanData);
+    Object.assign(node, cleanData);
     node.update();
   }
 }

--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -1051,6 +1051,11 @@ export class TreeNode {
   ): TreeNodeValue[] {
     const { tree } = this;
     const options = {
+      // 为 true, 为 UI 操作，状态变更受 disabled 影响
+      // 为 false, 为值操作, 状态变更不受 disabled 影响
+      isAction: true,
+      // 为 true, 直接操作节点状态
+      // 为 false, 返回预期状态
       directly: false,
       ...opts,
     };
@@ -1058,6 +1063,10 @@ export class TreeNode {
     let map = tree.activedMap;
     if (!options.directly) {
       map = new Map(tree.activedMap);
+    }
+    if (options.isAction && this.isDisabled()) {
+      // 对于 UI 动作，禁用时不可切换激活状态
+      return tree.getActived(map);
     }
     if (this.isActivable()) {
       if (actived) {
@@ -1105,8 +1114,8 @@ export class TreeNode {
     const { tree } = this;
     const config = tree.config || {};
     const options: TypeSettingOptions = {
-      // 为 true, 为 UI 操作，状态扩散受 disabled 影响
-      // 为 false, 为值操作, 状态扩散不受 disabled 影响
+      // 为 true, 为 UI 操作，状态变更受 disabled 影响
+      // 为 false, 为值操作, 状态变更不受 disabled 影响
       isAction: true,
       // 为 true, 直接操作节点状态
       // 为 false, 返回预期状态

--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -1315,7 +1315,7 @@ export class TreeNode {
    * 设置节点禁用状态
    * @return void
    */
-  private setDisabled(disabled: boolean) {
+  public setDisabled(disabled: boolean) {
     this.disabled = disabled;
     this.update();
     this.updateChildren();

--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -740,21 +740,25 @@ export class TreeNode {
   public isDisabledState(): boolean {
     const { tree, parent } = this;
     const { config } = tree;
-    const { disabled, disableCheck } = config;
+    const { disabled, disableCheck, checkStrictly } = config;
     let state = disabled || false;
     if (this.disabled) {
       // 整个树被禁用，则节点为禁用状态
       state = true;
     }
-    if (parent?.isDisabledState()) {
+    if (!checkStrictly && parent?.isDisabledState()) {
+      // 如果 checkStrictly 为 false
       // 父节点被禁用，则子节点也为禁用状态
       state = true;
     }
-    if (typeof disableCheck === 'boolean' && disableCheck) {
-      state = true;
-    }
-    if (typeof disableCheck === 'function' && disableCheck(this.getModel())) {
-      state = true;
+    if (typeof disableCheck === 'boolean') {
+      if (disableCheck) {
+        state = true;
+      }
+    } else if (typeof disableCheck === 'function') {
+      if (disableCheck(this.getModel())) {
+        state = true;
+      }
     }
     return state;
   }

--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -991,8 +991,8 @@ export class TreeNode {
    * - 仅返回预期状态值数组，不直接操作状态
    * @return string[] 当前树展开的节点值数组
    */
-  public toggleExpanded(): TreeNodeValue[] {
-    return this.setExpanded(!this.isExpanded());
+  public toggleExpanded(opts?: TypeSettingOptions): TreeNodeValue[] {
+    return this.setExpanded(!this.isExpanded(), opts);
   }
 
   /**
@@ -1070,8 +1070,8 @@ export class TreeNode {
    * - 仅返回预期状态值数组，不直接操作状态
    * @return string[] 当前树激活的节点值数组
    */
-  public toggleActived(): TreeNodeValue[] {
-    return this.setActived(!this.isActived());
+  public toggleActived(opts?: TypeSettingOptions): TreeNodeValue[] {
+    return this.setActived(!this.isActived(), opts);
   }
 
   /**
@@ -1162,15 +1162,15 @@ export class TreeNode {
    * - 仅返回预期状态值数组，不直接操作状态
    * @return string[] 当前树选中的节点值数组
    */
-  public toggleChecked(): TreeNodeValue[] {
+  public toggleChecked(opts?: TypeSettingOptions): TreeNodeValue[] {
     if (this.isIndeterminate()) {
       // 当前节点为半选情况下需要判断子节点是否尽可能全部选中
       // 存在可操作的未选中的子节点，则应当尽可能选中子节点
       // 不存在可操作的未选中的子节点，则应取消选中子节点
       const expectState = this.hasEnableUnCheckedChild();
-      return this.setChecked(expectState);
+      return this.setChecked(expectState, opts);
     }
-    return this.setChecked(!this.isChecked());
+    return this.setChecked(!this.isChecked(), opts);
   }
 
   /**

--- a/js/tree/tree-store.ts
+++ b/js/tree/tree-store.ts
@@ -52,6 +52,7 @@ function nextTick(fn: () => void): Promise<void> {
  * @param {boolean} [options.checkable=false] 节点是否可选中
  * @param {boolean} [options.checkStrictly=false] 节点选中是否使用严格模式
  * @param {boolean} [options.disabled=false] 节点是否禁用
+ * @param {boolean|function} [options.disableCheck=false] 节点被禁用的条件
  * @param {boolean} [options.draggable=false] 节点是否可拖动
  * @param {function} [options.load=null] 节点延迟加载函数
  * @param {boolean} [options.lazy=false] 节点是否使用延迟加载模式
@@ -121,6 +122,7 @@ export class TreeStore {
       checkable: false,
       checkStrictly: false,
       disabled: false,
+      disableCheck: false,
       draggable: false,
       load: null,
       lazy: false,

--- a/js/tree/types.ts
+++ b/js/tree/types.ts
@@ -257,6 +257,8 @@ export interface TypeTreeStoreOptions {
   checkStrictly?: boolean;
   // 禁用整个树
   disabled?: boolean;
+  // 指定节点禁用条件
+  disableCheck?: boolean | TypeTreeFilter;
   // 节点是否可拖动
   draggable?: boolean,
   // 节点加载函数
@@ -267,7 +269,7 @@ export interface TypeTreeStoreOptions {
   valueMode?: TypeValueMode;
   // 节点过滤函数
   // filter?: (node: TreeNode) => boolean;
-  filter?: (node: TreeNodeModel<TypeTreeNodeData>) => boolean;
+  filter?: TypeTreeFilter;
   // load函数运行后触发
   onLoad?: Function;
   // 节点增删改查后触发

--- a/js/tree/types.ts
+++ b/js/tree/types.ts
@@ -226,6 +226,8 @@ export type TypeTreeFilter = (node: TreeNodeModel<TypeTreeNodeData>) => boolean;
 
 export type TypeUpdatedMap = Map<TreeNodeValue, string>;
 
+export type TypeFnOperation = (node: TreeNode) => void;
+
 export interface TypeTreeEventState {
   node?: TreeNode;
   nodes?: TreeNode[];

--- a/js/tree/types.ts
+++ b/js/tree/types.ts
@@ -112,6 +112,10 @@ export interface TreeNodeModelProps<DataOption extends TreeOptionData = TreeOpti
    * 当前节点是否处于加载中状态
    */
   loading: boolean;
+  /**
+   * 当前节点是否被禁用
+   */
+  disabled: boolean;
 }
 
 export interface TreeNodeModel<

--- a/test/unit/tree/disabled.test.js
+++ b/test/unit/tree/disabled.test.js
@@ -379,5 +379,72 @@ describe('tree:disabled', () => {
       expect(t1d2.checked).toBe(false);
       expect(t1d3.checked).toBe(false);
     });
+
+    it('被禁用子节点选中态不一致，父节点操作时，子节点选中态也可以得到变更', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+      });
+      tree.append([{
+        value: 't1',
+        children: [{
+          value: 't1.1',
+        }, {
+          value: 't1.2',
+        }, {
+          value: 't1.3',
+        }, {
+          value: 't1.4',
+        }],
+      }]);
+
+      const t1 = tree.getNode('t1');
+      const t1d1 = tree.getNode('t1.1');
+      const t1d2 = tree.getNode('t1.2');
+      const t1d3 = tree.getNode('t1.3');
+      const t1d4 = tree.getNode('t1.4');
+
+      t1d1.setChecked(true, {
+        directly: true,
+      });
+      t1d1.setDisabled(true);
+      t1d2.setDisabled(true);
+      expect(t1.isDisabled()).toBe(false);
+      expect(t1.checked).toBe(false);
+      expect(t1.indeterminate).toBe(true);
+      expect(t1d1.isDisabled()).toBe(true);
+      expect(t1d1.checked).toBe(true);
+      expect(t1d2.isDisabled()).toBe(true);
+      expect(t1d2.checked).toBe(false);
+
+      t1d3.setChecked(true, {
+        directly: true,
+      });
+      expect(t1.checked).toBe(false);
+      expect(t1.indeterminate).toBe(true);
+      expect(t1d1.checked).toBe(true);
+      expect(t1d2.checked).toBe(false);
+      expect(t1d3.checked).toBe(true);
+      expect(t1d4.checked).toBe(false);
+
+      t1.toggleChecked({
+        directly: true,
+      });
+      expect(t1.checked).toBe(false);
+      expect(t1.indeterminate).toBe(true);
+      expect(t1d1.checked).toBe(true);
+      expect(t1d2.checked).toBe(false);
+      expect(t1d3.checked).toBe(true);
+      expect(t1d4.checked).toBe(true);
+
+      t1.toggleChecked({
+        directly: true,
+      });
+      expect(t1.checked).toBe(false);
+      expect(t1.indeterminate).toBe(true);
+      expect(t1d1.checked).toBe(true);
+      expect(t1d2.checked).toBe(false);
+      expect(t1d3.checked).toBe(false);
+      expect(t1d4.checked).toBe(false);
+    });
   });
 });

--- a/test/unit/tree/disabled.test.js
+++ b/test/unit/tree/disabled.test.js
@@ -6,7 +6,7 @@ import TreeStore from '../../../js/tree/tree-store';
 // 2. treeNode 上的 setChecked 方法，受禁用影响
 // 3. 选中态向下传播时，受节点禁用状态影响，向上传播不影响
 describe('tree:disabled', () => {
-  describe('treeStore:setChecked', () => {
+  describe('值操作', () => {
     it('整个树为禁用状态，值操作可以选中节点', async () => {
       const tree = new TreeStore({
         checkable: true,
@@ -28,7 +28,30 @@ describe('tree:disabled', () => {
     });
   });
 
-  describe('treeStore:replaceChecked()', () => {
+  it('整个树为禁用状态, 节点直接设值可以切换选中态', async () => {
+    const tree = new TreeStore({
+      checkable: true,
+      disabled: true,
+    });
+    tree.append([{
+      value: 't1',
+      children: [{
+        value: 't1.1',
+      }],
+    }]);
+
+    const t1 = tree.getNode('t1');
+    const t1d1 = tree.getNode('t1.1');
+
+    tree.getNode('t1.1').setChecked(true, {
+      isAction: false,
+      directly: true,
+    });
+    expect(t1.checked).toBe(true);
+    expect(t1d1.checked).toBe(true);
+  });
+
+  describe('重设选中态', () => {
     it('整个树为禁用状态，重设选中态不受影响', async () => {
       const tree = new TreeStore({
         checkable: true,
@@ -65,7 +88,7 @@ describe('tree:disabled', () => {
     });
   });
 
-  describe('treeNode:initChecked()', () => {
+  describe('初始化', () => {
     it('整个树为禁用状态，初始化选中态不受影响', async () => {
       const tree = new TreeStore({
         checkable: true,
@@ -98,7 +121,79 @@ describe('tree:disabled', () => {
     });
   });
 
-  describe('treeNode:setChecked()', () => {
+  describe('禁用状态的关联', () => {
+    it('子节点禁用，父节点不受影响', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+      });
+      tree.append([{
+        value: 't1',
+        children: [{
+          value: 't1.1',
+        }, {
+          value: 't1.2',
+          disabled: true,
+        }],
+      }]);
+
+      const t1 = tree.getNode('t1');
+      const t1d1 = tree.getNode('t1.1');
+      const t1d2 = tree.getNode('t1.2');
+
+      expect(t1.isDisabled()).toBe(false);
+      expect(t1d1.isDisabled()).toBe(false);
+      expect(t1d2.isDisabled()).toBe(true);
+    });
+
+    it('父节点禁用，子节点也会被禁用', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+      });
+      tree.append([{
+        value: 't1',
+        disabled: true,
+        children: [{
+          value: 't1.1',
+        }, {
+          value: 't1.2',
+        }],
+      }]);
+
+      const t1 = tree.getNode('t1');
+      const t1d1 = tree.getNode('t1.1');
+      const t1d2 = tree.getNode('t1.2');
+
+      expect(t1.isDisabled()).toBe(true);
+      expect(t1d1.isDisabled()).toBe(true);
+      expect(t1d2.isDisabled()).toBe(true);
+    });
+
+    it('checkStrictly 为 true, 父节点禁用，子节点不会被禁用', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+        checkStrictly: true,
+      });
+      tree.append([{
+        value: 't1',
+        disabled: true,
+        children: [{
+          value: 't1.1',
+        }, {
+          value: 't1.2',
+        }],
+      }]);
+
+      const t1 = tree.getNode('t1');
+      const t1d1 = tree.getNode('t1.1');
+      const t1d2 = tree.getNode('t1.2');
+
+      expect(t1.isDisabled()).toBe(true);
+      expect(t1d1.isDisabled()).toBe(false);
+      expect(t1d2.isDisabled()).toBe(false);
+    });
+  });
+
+  describe('UI 操作', () => {
     it('整个树为禁用状态, UI check 无法切换选中态', async () => {
       const tree = new TreeStore({
         checkable: true,
@@ -119,29 +214,6 @@ describe('tree:disabled', () => {
       });
       expect(t1.checked).toBe(false);
       expect(t1d1.checked).toBe(false);
-    });
-
-    it('整个树为禁用状态, 直接设值可以切换选中态', async () => {
-      const tree = new TreeStore({
-        checkable: true,
-        disabled: true,
-      });
-      tree.append([{
-        value: 't1',
-        children: [{
-          value: 't1.1',
-        }],
-      }]);
-
-      const t1 = tree.getNode('t1');
-      const t1d1 = tree.getNode('t1.1');
-
-      tree.getNode('t1.1').setChecked(true, {
-        isAction: false,
-        directly: true,
-      });
-      expect(t1.checked).toBe(true);
-      expect(t1d1.checked).toBe(true);
     });
 
     it('UI check 向下扩散被 disabled 阻塞', async () => {
@@ -198,47 +270,114 @@ describe('tree:disabled', () => {
       expect(t1d2.checked).toBe(true);
     });
 
-    it('UI check 向上扩散不被 disabled 阻塞', async () => {
+    it('子节点未选中且被禁用, UI check 节点产生了半选后, 父节点可在半选与未选中之间切换', async () => {
       const tree = new TreeStore({
         checkable: true,
       });
       tree.append([{
         value: 't1',
-        disabled: true,
         children: [{
           value: 't1.1',
+          disabled: true,
         }, {
           value: 't1.2',
+        }, {
+          value: 't1.3',
         }],
       }]);
 
       const t1 = tree.getNode('t1');
       const t1d1 = tree.getNode('t1.1');
       const t1d2 = tree.getNode('t1.2');
+      const t1d3 = tree.getNode('t1.3');
 
-      tree.getNode('t1').setChecked(true, {
+      expect(t1.isDisabled()).toBe(false);
+      expect(t1d1.isDisabled()).toBe(true);
+
+      t1d2.setChecked(true, {
+        directly: true,
+      });
+      expect(t1.checked).toBe(false);
+      expect(t1.indeterminate).toBe(true);
+      expect(t1d1.checked).toBe(false);
+      expect(t1d2.checked).toBe(true);
+      expect(t1d3.checked).toBe(false);
+
+      t1.toggleChecked({
+        directly: true,
+      });
+      expect(t1.checked).toBe(false);
+      expect(t1.indeterminate).toBe(true);
+      expect(t1d1.checked).toBe(false);
+      expect(t1d2.checked).toBe(true);
+      expect(t1d3.checked).toBe(true);
+
+      t1.toggleChecked({
         directly: true,
       });
       expect(t1.checked).toBe(false);
       expect(t1.indeterminate).toBe(false);
       expect(t1d1.checked).toBe(false);
       expect(t1d2.checked).toBe(false);
+      expect(t1d3.checked).toBe(false);
+    });
 
-      tree.getNode('t1.1').setChecked(true, {
+    it('子节点被选中且被禁用, UI check 节点产生了半选后, 父节点可在半选与选中之间切换', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+      });
+      tree.append([{
+        value: 't1',
+        children: [{
+          value: 't1.1',
+        }, {
+          value: 't1.2',
+        }, {
+          value: 't1.3',
+        }],
+      }]);
+
+      const t1 = tree.getNode('t1');
+      const t1d1 = tree.getNode('t1.1');
+      const t1d2 = tree.getNode('t1.2');
+      const t1d3 = tree.getNode('t1.3');
+
+      t1d1.setChecked(true, {
+        directly: true,
+      });
+      t1d1.setDisabled(true);
+      expect(t1.isDisabled()).toBe(false);
+      expect(t1d1.isDisabled()).toBe(true);
+      expect(t1d1.checked).toBe(true);
+      expect(t1.checked).toBe(false);
+      expect(t1.indeterminate).toBe(true);
+
+      t1d2.setChecked(true, {
         directly: true,
       });
       expect(t1.checked).toBe(false);
       expect(t1.indeterminate).toBe(true);
       expect(t1d1.checked).toBe(true);
-      expect(t1d2.checked).toBe(false);
+      expect(t1d2.checked).toBe(true);
+      expect(t1d3.checked).toBe(false);
 
-      tree.getNode('t1.2').setChecked(true, {
+      t1.toggleChecked({
         directly: true,
       });
       expect(t1.checked).toBe(true);
       expect(t1.indeterminate).toBe(false);
       expect(t1d1.checked).toBe(true);
       expect(t1d2.checked).toBe(true);
+      expect(t1d3.checked).toBe(true);
+
+      t1.toggleChecked({
+        directly: true,
+      });
+      expect(t1.checked).toBe(false);
+      expect(t1.indeterminate).toBe(true);
+      expect(t1d1.checked).toBe(true);
+      expect(t1d2.checked).toBe(false);
+      expect(t1d3.checked).toBe(false);
     });
   });
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue/issues/2920

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
需按照下列目标，改进 tree 组件模型:
父节点被禁用，所有子节点一并呈现禁用状态，除非 checkStrictly = true。
父节点操作，不影响被禁用的子节点的原始选中状态。
子节点被禁用且未选中，父节点半选状态再次点击可切换为未选中状态。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree): tree 节点禁用状态逻辑改进

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
