### PR TITLE
feat: 为了适配，datepicker组件新增取消禁用日期选择限制的能力，在获取日期的方法中，新增一个参数用于取消禁用日期选择限制

### DIFF
--- a/docs/web/api/date-picker.en-US.md
+++ b/docs/web/api/date-picker.en-US.md
@@ -78,6 +78,10 @@ You can use `DatePickerPanel` and `DateRangePickerPanel` separately. You can ass
 
 {{ panel }}
 
+### An unbounded date range selector。
+
+{{ disable-range-limit }}
+
 ## FAQ
 
 ### The backend data format is special. How can I format the date quickly?

--- a/docs/web/api/date-picker.en-US.md
+++ b/docs/web/api/date-picker.en-US.md
@@ -80,7 +80,7 @@ You can use `DatePickerPanel` and `DateRangePickerPanel` separately. You can ass
 
 ### An unbounded date range selector。
 
-{{ disable-range-limit }}
+{{ cancel-range-limit }}
 
 ## FAQ
 

--- a/docs/web/api/date-picker.md
+++ b/docs/web/api/date-picker.md
@@ -76,6 +76,10 @@ spline: form
 
 {{ panel }}
 
+### 不限制日期区间选择范围的选择器。
+
+{{ disable-range-limit }}
+
 ## FAQ
 
 ### 后端数据格式要求比较特殊，如何快捷格式化日期？

--- a/docs/web/api/date-picker.md
+++ b/docs/web/api/date-picker.md
@@ -78,7 +78,7 @@ spline: form
 
 ### 不限制日期区间选择范围的选择器。
 
-{{ disable-range-limit }}
+{{ cancel-range-limit }}
 
 ## FAQ
 

--- a/js/date-picker/utils.ts
+++ b/js/date-picker/utils.ts
@@ -204,7 +204,7 @@ export interface OptionsType {
   dayjsLocale?: string;
   monthLocal?: string[];
   quarterLocal?: string[];
-  disableDateSelectLimit?: boolean;
+  cancelRangeSelectLimit?: boolean;
 }
 
 export function getWeeks(
@@ -216,7 +216,7 @@ export function getWeeks(
     minDate,
     maxDate,
     dayjsLocale = 'zh-cn',
-    disableDateSelectLimit = false,
+    cancelRangeSelectLimit = false,
   }: OptionsType,
 ) {
   const prependDay = getFirstDayOfMonth({ year, month });
@@ -232,7 +232,7 @@ export function getWeeks(
       active: false,
       value: currentDay,
       disabled: (isFunction(disableDate) && disableDate(currentDay))
-        || (!disableDateSelectLimit && outOfRanges(currentDay, minDate, maxDate)),
+        || (!cancelRangeSelectLimit && outOfRanges(currentDay, minDate, maxDate)),
       now: isSame(today, currentDay),
       firstDayOfMonth: i === 1,
       lastDayOfMonth: i === maxDays,
@@ -248,7 +248,7 @@ export function getWeeks(
         text: prependDay.getDate().toString(),
         active: false,
         value: new Date(prependDay),
-        disabled: (isFunction(disableDate) && disableDate(prependDay)) || (!disableDateSelectLimit && outOfRanges(prependDay, minDate, maxDate)),
+        disabled: (isFunction(disableDate) && disableDate(prependDay)) || (!cancelRangeSelectLimit && outOfRanges(prependDay, minDate, maxDate)),
         additional: true, // 非当前月
         type: 'prev-month',
         dayjsObj: dayjs(prependDay).locale(dayjsLocale),
@@ -265,7 +265,7 @@ export function getWeeks(
       text: appendDay.getDate(),
       active: false,
       value: new Date(appendDay),
-      disabled: (isFunction(disableDate) && disableDate(appendDay)) || (!disableDateSelectLimit && outOfRanges(appendDay, minDate, maxDate)),
+      disabled: (isFunction(disableDate) && disableDate(appendDay)) || (!cancelRangeSelectLimit && outOfRanges(appendDay, minDate, maxDate)),
       additional: true, // 非当前月
       type: 'next-month',
       dayjsObj: dayjs(appendDay).locale(dayjsLocale),
@@ -297,7 +297,7 @@ export function getQuarters(
     maxDate,
     quarterLocal,
     dayjsLocale = 'zh-cn',
-    disableDateSelectLimit = false,
+    cancelRangeSelectLimit = false,
   }: OptionsType,
 ) {
   const quarterArr = [];
@@ -309,7 +309,7 @@ export function getQuarters(
     quarterArr.push({
       value: date,
       now: isSame(date, today, 'quarter'),
-      disabled: (isFunction(disableDate) && disableDate(date)) || (!disableDateSelectLimit && outOfRanges(date, minDate, maxDate)),
+      disabled: (isFunction(disableDate) && disableDate(date)) || (!cancelRangeSelectLimit && outOfRanges(date, minDate, maxDate)),
       active: false,
       text: quarterLocal[i - 1],
       dayjsObj: dayjs(date).locale(dayjsLocale),
@@ -326,7 +326,7 @@ export function getYears(
     minDate,
     maxDate,
     dayjsLocale = 'zh-cn',
-    disableDateSelectLimit = false,
+    cancelRangeSelectLimit = false,
   }: OptionsType,
 ) {
   const startYear = parseInt((year / 10).toString(), 10) * 10;
@@ -342,7 +342,7 @@ export function getYears(
     yearArr.push({
       value: date,
       now: isSame(date, today, 'year'),
-      disabled: (isFunction(disableDate) && disableDate(date)) || (!disableDateSelectLimit && outOfRanges(date, minDate, maxDate)),
+      disabled: (isFunction(disableDate) && disableDate(date)) || (!cancelRangeSelectLimit && outOfRanges(date, minDate, maxDate)),
       active: false,
       text: `${date.getFullYear()}`,
       dayjsObj: dayjs(date).locale(dayjsLocale),
@@ -354,7 +354,7 @@ export function getYears(
 
 export function getMonths(year: number, params: OptionsType) {
   const {
-    disableDate = () => false, minDate, maxDate, monthLocal, dayjsLocale = 'zh-cn', disableDateSelectLimit = false,
+    disableDate = () => false, minDate, maxDate, monthLocal, dayjsLocale = 'zh-cn', cancelRangeSelectLimit = false,
   } = params;
   const MonthArr = [];
   const today = getToday();
@@ -365,7 +365,7 @@ export function getMonths(year: number, params: OptionsType) {
     MonthArr.push({
       value: date,
       now: isSame(date, today, 'month'),
-      disabled: (isFunction(disableDate) && disableDate(date)) || (!disableDateSelectLimit && outOfRanges(date, minDate, maxDate)),
+      disabled: (isFunction(disableDate) && disableDate(date)) || (!cancelRangeSelectLimit && outOfRanges(date, minDate, maxDate)),
       active: false,
       text: monthLocal[date.getMonth()], // `${date.getMonth() + 1} ${monthText || '月'}`,
       dayjsObj: dayjs(date).locale(dayjsLocale),

--- a/js/date-picker/utils.ts
+++ b/js/date-picker/utils.ts
@@ -204,6 +204,7 @@ export interface OptionsType {
   dayjsLocale?: string;
   monthLocal?: string[];
   quarterLocal?: string[];
+  disableDateSelectLimit?: boolean;
 }
 
 export function getWeeks(
@@ -215,6 +216,7 @@ export function getWeeks(
     minDate,
     maxDate,
     dayjsLocale = 'zh-cn',
+    disableDateSelectLimit = false,
   }: OptionsType,
 ) {
   const prependDay = getFirstDayOfMonth({ year, month });
@@ -230,7 +232,7 @@ export function getWeeks(
       active: false,
       value: currentDay,
       disabled: (isFunction(disableDate) && disableDate(currentDay))
-        || outOfRanges(currentDay, minDate, maxDate),
+        || (!disableDateSelectLimit && outOfRanges(currentDay, minDate, maxDate)),
       now: isSame(today, currentDay),
       firstDayOfMonth: i === 1,
       lastDayOfMonth: i === maxDays,
@@ -246,7 +248,7 @@ export function getWeeks(
         text: prependDay.getDate().toString(),
         active: false,
         value: new Date(prependDay),
-        disabled: (isFunction(disableDate) && disableDate(prependDay)) || outOfRanges(prependDay, minDate, maxDate),
+        disabled: (isFunction(disableDate) && disableDate(prependDay)) || (!disableDateSelectLimit && outOfRanges(prependDay, minDate, maxDate)),
         additional: true, // 非当前月
         type: 'prev-month',
         dayjsObj: dayjs(prependDay).locale(dayjsLocale),
@@ -263,7 +265,7 @@ export function getWeeks(
       text: appendDay.getDate(),
       active: false,
       value: new Date(appendDay),
-      disabled: (isFunction(disableDate) && disableDate(appendDay)) || outOfRanges(appendDay, minDate, maxDate),
+      disabled: (isFunction(disableDate) && disableDate(appendDay)) || (!disableDateSelectLimit && outOfRanges(appendDay, minDate, maxDate)),
       additional: true, // 非当前月
       type: 'next-month',
       dayjsObj: dayjs(appendDay).locale(dayjsLocale),
@@ -295,6 +297,7 @@ export function getQuarters(
     maxDate,
     quarterLocal,
     dayjsLocale = 'zh-cn',
+    disableDateSelectLimit = false,
   }: OptionsType,
 ) {
   const quarterArr = [];
@@ -306,7 +309,7 @@ export function getQuarters(
     quarterArr.push({
       value: date,
       now: isSame(date, today, 'quarter'),
-      disabled: (isFunction(disableDate) && disableDate(date)) || outOfRanges(date, minDate, maxDate),
+      disabled: (isFunction(disableDate) && disableDate(date)) || (!disableDateSelectLimit && outOfRanges(date, minDate, maxDate)),
       active: false,
       text: quarterLocal[i - 1],
       dayjsObj: dayjs(date).locale(dayjsLocale),
@@ -323,6 +326,7 @@ export function getYears(
     minDate,
     maxDate,
     dayjsLocale = 'zh-cn',
+    disableDateSelectLimit = false,
   }: OptionsType,
 ) {
   const startYear = parseInt((year / 10).toString(), 10) * 10;
@@ -338,7 +342,7 @@ export function getYears(
     yearArr.push({
       value: date,
       now: isSame(date, today, 'year'),
-      disabled: (isFunction(disableDate) && disableDate(date)) || outOfRanges(date, minDate, maxDate),
+      disabled: (isFunction(disableDate) && disableDate(date)) || (!disableDateSelectLimit && outOfRanges(date, minDate, maxDate)),
       active: false,
       text: `${date.getFullYear()}`,
       dayjsObj: dayjs(date).locale(dayjsLocale),
@@ -350,7 +354,7 @@ export function getYears(
 
 export function getMonths(year: number, params: OptionsType) {
   const {
-    disableDate = () => false, minDate, maxDate, monthLocal, dayjsLocale = 'zh-cn',
+    disableDate = () => false, minDate, maxDate, monthLocal, dayjsLocale = 'zh-cn', disableDateSelectLimit = false,
   } = params;
   const MonthArr = [];
   const today = getToday();
@@ -361,7 +365,7 @@ export function getMonths(year: number, params: OptionsType) {
     MonthArr.push({
       value: date,
       now: isSame(date, today, 'month'),
-      disabled: (isFunction(disableDate) && disableDate(date)) || outOfRanges(date, minDate, maxDate),
+      disabled: (isFunction(disableDate) && disableDate(date)) || (!disableDateSelectLimit && outOfRanges(date, minDate, maxDate)),
       active: false,
       text: monthLocal[date.getMonth()], // `${date.getMonth() + 1} ${monthText || '月'}`,
       dayjsObj: dayjs(date).locale(dayjsLocale),


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？
分别在获取日期的getWeeks、getQuarters、getYears、getMonths方法，类型为OptionsType参数中新增了一个属性
名称：disableDateSelectLimit
类型：Boolean
默认值：false，
说明：用于支持datepicker组件新增取消禁用日期选择限制的能力， disableDateSelectLimit参数的传入来源于
https://github.com/Tencent/tdesign-vue-next/pull/3718  这个pr中新增的props参数: disableDateSelectLimit

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
