### PR TITLE
fix: 🐛 tree 组件，解决首个子节点选中导致全部节点选中的问题

### DIFF
--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -222,10 +222,10 @@ export class TreeNode {
       }
     });
 
-    // 初始化节点状态
+    // 初始化节点激活状态
     this.initActived();
+    // 展开状态影响了子节点的显示状态，所以要在子节点插入之前初始化展开状态
     this.initExpanded();
-    this.initChecked();
 
     // 这里的子节点加载逻辑不能放到状态初始化之前
     // 因为子节点状态计算依赖父节点初始化状态
@@ -235,8 +235,9 @@ export class TreeNode {
       this.loadChildren();
     }
 
-    // checked 状态依赖于子节点状态
-    // 因此子节点插入之后需要再次更新状态
+    // 节点的选中状态同时依赖于子节点状态与父节点状态
+    // 因此在子节点插入之后再更新选中状态
+    this.initChecked();
     this.updateChecked();
 
     // 标记节点更新
@@ -258,10 +259,12 @@ export class TreeNode {
     if (this.checked) {
       checkedMap.set(value, true);
     }
-    if (!checkStrictly && parent?.isChecked()) {
+    // 这里不可以使用 parent.isChecked 方法
+    // 因为当前节点创建时尚未插入父节点的 children 数组，可能父节点选中态仅受到之前子节点状态的影响
+    // 这会导致父节点状态计算错误，进而引发子节点变更了选中状态
+    if (!checkStrictly && parent?.checked) {
       checkedMap.set(value, true);
     }
-    this.updateChecked();
   }
 
   /**

--- a/test/unit/tree/checkable.test.js
+++ b/test/unit/tree/checkable.test.js
@@ -1249,4 +1249,90 @@ describe('tree:checkable', () => {
       expect(t1d2.isChecked()).toBe(false);
     });
   });
+
+  describe('treeNode:initChecked', () => {
+    it('单一子节点选中，父节点为选中态', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+      });
+      tree.append([{
+        value: 't1',
+        children: [{
+          value: 't1.1',
+          checked: true,
+        }],
+      }]);
+
+      expect(tree.getChecked().length).toBe(1);
+      expect(tree.getChecked()[0]).toBe('t1.1');
+      expect(tree.getNode('t1').checked).toBe(true);
+      expect(tree.getNode('t1.1').checked).toBe(true);
+    });
+
+    it('父节点为选中态，子节点也为选中态', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+      });
+      tree.append([{
+        value: 't1',
+        checked: true,
+        children: [{
+          value: 't1.1',
+        }, {
+          value: 't1.2',
+        }],
+      }]);
+
+      expect(tree.getChecked().length).toBe(2);
+      expect(tree.getChecked()[0]).toBe('t1.1');
+      expect(tree.getChecked()[1]).toBe('t1.2');
+      expect(tree.getNode('t1').checked).toBe(true);
+      expect(tree.getNode('t1.1').checked).toBe(true);
+      expect(tree.getNode('t1.2').checked).toBe(true);
+    });
+
+    it('第一个子节点为选中态，父节点为半选', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+      });
+      tree.append([{
+        value: 't1',
+        children: [{
+          value: 't1.1',
+          checked: true,
+        }, {
+          value: 't1.2',
+        }],
+      }]);
+
+      expect(tree.getChecked().length).toBe(1);
+      expect(tree.getChecked()[0]).toBe('t1.1');
+      expect(tree.getNode('t1').checked).toBe(false);
+      expect(tree.getNode('t1').isIndeterminate()).toBe(true);
+      expect(tree.getNode('t1.1').checked).toBe(true);
+      expect(tree.getNode('t1.2').checked).toBe(false);
+    });
+
+    it('末尾子节点为选中态，父节点为半选', async () => {
+      const tree = new TreeStore({
+        checkable: true,
+      });
+      tree.append([{
+        value: 't1',
+        children: [{
+          value: 't1.1',
+        }, {
+          value: 't1.2',
+          checked: true,
+        }],
+      }]);
+
+      expect(tree.getChecked().length).toBe(1);
+      expect(tree.getChecked()[0]).toBe('t1.2');
+      expect(tree.getNode('t1').checked).toBe(false);
+      expect(tree.getNode('t1').isIndeterminate()).toBe(true);
+      expect(tree.getNode('t1.1').checked).toBe(false);
+      expect(tree.getNode('t1.2').checked).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue/issues/2877

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题: 子节点初始化数据设置 checked 为 true 时。分支下所有节点被选中了。
解决方案: 梳理初始化流程状态，避免父节点过早被影响选中态

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree): 解决首个子节点选中导致全部节点选中的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
