### PR TITLE
fix(upload): 修复批量上传组件添加同名文件触发额外 onValidate 事件的问题

### DIFF
--- a/js/upload/main.ts
+++ b/js/upload/main.ts
@@ -362,8 +362,9 @@ export function validateFile(
     // 上传文件数量限制
     let lengthOverLimit = false;
     if (max && tmpFiles.length && !params.isBatchUpload) {
+      const tmpFilesLenToBeAdded = tmpFiles.length;
       tmpFiles = tmpFiles.slice(0, max - uploadValue.length);
-      if (tmpFiles.length !== files.length) {
+      if (tmpFilesLenToBeAdded + uploadValue.length > max) {
         lengthOverLimit = true;
       }
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

See below: 
[[Upload] 上传数量未达到 max 时，因添加文件包含同名文件触发额外 validateType #3792](https://github.com/Tencent/tdesign-vue-next/issues/3792)

### 💡 需求背景和解决方案

超出文件数量限制的判断应该使用 tmpFilesLenToBeAdded + uploadValue.length > max ,
即未经过 slice 之前将要添加的文件数量进行记录， 然后与之前的数量 uploadValue.length 相加后比较。

### 📝 更新日志

- fix(upload): 修复批量上传组件添加同名文件触发额外 onValidate 事件的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
