### PR TITLE
fix: resoved style issues of tree component does not handle content e…

### DIFF
--- a/style/web/components/tree/_index.less
+++ b/style/web/components/tree/_index.less
@@ -253,6 +253,7 @@
     --ripple-color: @bg-color-container-active;
 
     flex-wrap: nowrap;
+    // resoved style issues of tree component does not handle content exceedance
     flex: 1;
     padding: @tree-label-padding;
     margin-left: @tree-label-margin-left;

--- a/style/web/components/tree/_index.less
+++ b/style/web/components/tree/_index.less
@@ -253,7 +253,7 @@
     --ripple-color: @bg-color-container-active;
 
     flex-wrap: nowrap;
-    flex: 0 0 auto;
+    flex: 1;
     padding: @tree-label-padding;
     margin-left: @tree-label-margin-left;
     border-radius: @border-radius-default;


### PR DESCRIPTION
…xceedance

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue  
https://github.com/Tencent/tdesign-vue-next/issues/3789

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
需求背景：tdesign-vue-next框架用户提了issue反馈“如果t-tree__label太长时，会将#operations顶出显示范围”
解决方案：
首先解决这个问题，大致有两个方向，一种是内容超出后变成省略号，其次是换行，经过跟框架PMC成员沟通，确定的大致思路是超出后省略，但是查了下代码，省略相关的代码是已有的，那不生效的原因就是不同布局方案或者写法导致的宽度由内容去撑的原因了。
研究了目前tree组件对应的样式代码如下：
<img width="429" alt="image" src="https://github.com/Tencent/tdesign-common/assets/24938023/0ee7e08c-f536-4683-a696-c7ae8f59174f">
其中，flex:0 0 auto 是用内容撑空间，但是经过跟如果要实现让元素在超出指定宽度后就省略的话，这个就不能满足要求了。所以需要采用flex的值让其通过给定的宽度伸缩来实现这个省略的效果。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
