### PR TITLE
fix(date-picker): add dayjs updateLocale plugin to support correct week numbers

### DIFF
--- a/js/date-picker/utils.ts
+++ b/js/date-picker/utils.ts
@@ -7,6 +7,7 @@ import localeData from 'dayjs/plugin/localeData';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import updateLocale from 'dayjs/plugin/updateLocale';
 import chunk from 'lodash/chunk';
 import { parseToDayjs } from './format';
 
@@ -17,6 +18,7 @@ dayjs.extend(quarterOfYear);
 dayjs.extend(advancedFormat);
 dayjs.extend(customParseFormat);
 dayjs.extend(dayJsIsBetween);
+dayjs.extend(updateLocale);
 
 /**
  * 首字母大写
@@ -219,6 +221,9 @@ export function getWeeks(
     cancelRangeSelectLimit = false,
   }: OptionsType,
 ) {
+  // 更新 dayjs 已有的语言配置以获取正确的周数
+  dayjs.updateLocale(dayjsLocale, { weekStart: firstDayOfWeek });
+
   const prependDay = getFirstDayOfMonth({ year, month });
   const appendDay = getLastDayOfMonth({ year, month });
   const maxDays = getDaysInMonth({ year, month });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue-next/issues/3785

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

[更新 dayjs 已有的语言配置](https://day.js.org/docs/zh-CN/customization/customization) 以获取正确的周数。

- 以 `firstDayOfWeek` 为一周第 1 天，则这周的第 4 天我们记为星期 `x`；
- 本年度第一个星期 `x` 所在的星期是本年度的第一周。

![date-picker-week-number](https://github.com/Tencent/tdesign-common/assets/44917537/5543ce57-fd87-47ae-a03c-2d33d0e83c8d)

参考：https://github.com/iamkun/dayjs/issues/2237

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(date-picker): 添加 dayjs updateLocale 插件，以支持正确的周数

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
