### PR TITLE
fix: treeTable can not expand properly after folding all nodes

### DIFF
--- a/js/table/tree-store.ts
+++ b/js/table/tree-store.ts
@@ -577,15 +577,18 @@ class TableTreeStore<T extends TableRowData = TableRowData> {
    */
   foldAll(dataSource: T[], keys: KeysType) {
     const newData: T[] = [];
+    let index = 0;
     for (let i = 0, len = dataSource.length; i < len; i++) {
       const item = dataSource[i];
       const rowValue = get(item, keys.rowKey);
       const state = this.treeDataMap.get(rowValue);
-      state.rowIndex = state.level === 0 ? i : -1;
+      state.rowIndex = state.level === 0 ? index : -1;
+      console.log(state.rowIndex);
       state.expanded = false;
       state.expandChildrenLength = 0;
       if (state.level === 0) {
         newData.push(item);
+        index += 1;
       }
       const children = get(item, keys.childrenKey);
       if (children?.length) {

--- a/js/table/tree-store.ts
+++ b/js/table/tree-store.ts
@@ -583,7 +583,6 @@ class TableTreeStore<T extends TableRowData = TableRowData> {
       const rowValue = get(item, keys.rowKey);
       const state = this.treeDataMap.get(rowValue);
       state.rowIndex = state.level === 0 ? index : -1;
-      console.log(state.rowIndex);
       state.expanded = false;
       state.expandChildrenLength = 0;
       if (state.level === 0) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 树形结构表格，修复收起所有节点之后，展开其他节点位置不正确问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
