### PR TITLE
fix(table): fix table filter result style

### DIFF
--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -816,8 +816,9 @@
 
 .@{prefix}-table__row-filter-inner {
   position: sticky;
-  left: 0;
-  text-align: center;
+  left: 50%;
+  width: fit-content;
+  transform: translateX(-50%);
 }
 
 .@{prefix}-table__filter-result {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
无

### 💡 需求背景和解决方案
表格超出滚动时，筛选结果行不居中，导致必须滚动到中间才可以看见筛选结果。
解决方案: 让筛选结果宽度自适应内容 使用定位进行居中 保证滚动时结果也保持在中间
https://stackblitz.com/edit/unkuzj?file=src%2Fdemo.vue

### 📝 更新日志

- 修复表格可滚动时，表格筛选结果不居中

- [] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
