### PR TITLE
fix(Table): fix stripe style error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
   "less.validate": false,
   "scss.validate": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.stylelint": true,
-    "source.fixAll.eslint": true
+    "source.fixAll.stylelint": "explicit",
+    "source.fixAll.eslint": "explicit"
   },
   "cSpell.words": [
     "stylelint"

--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -291,13 +291,13 @@
     }
 
     &.@{prefix}-table--header-fixed {
-      > .@{prefix}-table__content > table > tbody tr:nth-of-type(even) {
+      > .@{prefix}-table__content > table > tbody tr.@{prefix}-table__row__even {
         background-color: @table-highlight-bg-color;
       }
     }
 
     &:not(.@{prefix}-table--header-fixed) {
-      > .@{prefix}-table__content > table > tbody > tr:nth-of-type(odd):not(.@{prefix}-table__expanded-row) {
+      > .@{prefix}-table__content > table > tbody > tr.@{prefix}-table__row__odd:not(.@{prefix}-table__expanded-row) {
         background-color: @table-highlight-bg-color;
       }
     }
@@ -305,13 +305,13 @@
     &.@{prefix}-table--hoverable {
 
       &.@{prefix}-table__header--fixed {
-        tbody tr:nth-of-type(even):hover {
+        tbody tr.@{prefix}-table__row__even:hover {
           background-color: @table-highlight-bg-color--hover;
         }
       }
 
       &:not(.@{prefix}-table__header--fixed) {
-        > .@{prefix}-table__content > table > tbody tr:nth-of-type(odd):hover {
+        > .@{prefix}-table__content > table > tbody tr.@{prefix}-table__row__odd:hover {
           background-color: @table-highlight-bg-color--hover;
         }
       }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix: https://github.com/Tencent/tdesign-react/issues/2669

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
pr: https://github.com/Tencent/tdesign-react/pull/2823
通过 table data 的 index 来判断添加 odd\even 的class类名来解决展开收起时，斑马纹跳动的bug。 `需要其他组件进行适配此样式`


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修复斑马纹效果的样式跳动问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
