### PR TITLE
fix: windows chrome滚动条样式问题

### DIFF
--- a/style/mobile/components/table/mixins/_scrollbar.less
+++ b/style/mobile/components/table/mixins/_scrollbar.less
@@ -5,8 +5,10 @@
 
 .scrollbar(@size: 6px, @borderSize: 0px) {
   // Firefox 等浏览器标准支持的滚动条样式设置
-  scrollbar-color: @scrollbar-color transparent;
-  scrollbar-width: thin;
+  @supports not selector(::-webkit-scrollbar) {
+    scrollbar-color: @scrollbar-color transparent;
+    scrollbar-width: thin;
+  }
   // Safari/Chrome 中滚动条样式设置
   &::-webkit-scrollbar {
     width: @size;
@@ -29,8 +31,10 @@
 
 .hideScrollbar() {
   /* firefox */
-  scrollbar-width: none;
-  overflow: -moz-scrollbars-none;
+  @supports not selector(::-webkit-scrollbar) {
+    scrollbar-width: none;
+    overflow: -moz-scrollbars-none;
+  }
 
   /* IE 10+ */
   -ms-overflow-style: none;

--- a/style/mobile/components/table/mixins/_scrollbar.less
+++ b/style/mobile/components/table/mixins/_scrollbar.less
@@ -5,6 +5,7 @@
 
 .scrollbar(@size: 6px, @borderSize: 0px) {
   // Firefox 等浏览器标准支持的滚动条样式设置
+  // Chrome support after v121 https://developer.chrome.com/docs/css-ui/scrollbar-styling
   @supports not selector(::-webkit-scrollbar) {
     scrollbar-color: @scrollbar-color transparent;
     scrollbar-width: thin;
@@ -31,6 +32,7 @@
 
 .hideScrollbar() {
   /* firefox */
+  // Chrome support after v121 https://developer.chrome.com/docs/css-ui/scrollbar-styling
   @supports not selector(::-webkit-scrollbar) {
     scrollbar-width: none;
     overflow: -moz-scrollbars-none;

--- a/style/web/mixins/_scrollbar.less
+++ b/style/web/mixins/_scrollbar.less
@@ -2,6 +2,7 @@
 
 .scrollbar(@size: 6px, @borderSize: 0px) {
   // Firefox 等浏览器标准支持的滚动条样式设置
+  // Chrome support after v121 https://developer.chrome.com/docs/css-ui/scrollbar-styling
   @supports not selector(::-webkit-scrollbar) {
     scrollbar-color: @scrollbar-color transparent;
     scrollbar-width: thin;

--- a/style/web/mixins/_scrollbar.less
+++ b/style/web/mixins/_scrollbar.less
@@ -2,8 +2,11 @@
 
 .scrollbar(@size: 6px, @borderSize: 0px) {
   // Firefox 等浏览器标准支持的滚动条样式设置
-  scrollbar-color: @scrollbar-color transparent;
-  scrollbar-width: thin;
+  @supports not selector(::-webkit-scrollbar) {
+    scrollbar-color: @scrollbar-color transparent;
+    scrollbar-width: thin;
+  }
+
   // Safari/Chrome 中滚动条样式设置
   &::-webkit-scrollbar {
     width: @size;
@@ -26,8 +29,10 @@
 
 .hideScrollbar() {
   /* firefox */
-  scrollbar-width: none;
-  overflow: -moz-scrollbars-none;
+  @supports not selector(::-webkit-scrollbar) {
+    scrollbar-width: none;
+    overflow: -moz-scrollbars-none;
+  }
 
   /* IE 10+ */
   -ms-overflow-style: none;

--- a/style/web/mixins/_scrollbar.less
+++ b/style/web/mixins/_scrollbar.less
@@ -30,6 +30,7 @@
 
 .hideScrollbar() {
   /* firefox */
+  // Chrome support after v121 https://developer.chrome.com/docs/css-ui/scrollbar-styling
   @supports not selector(::-webkit-scrollbar) {
     scrollbar-width: none;
     overflow: -moz-scrollbars-none;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue/issues/3121
https://github.com/Tencent/tdesign-vue/issues/3116
https://github.com/Tencent/tdesign-vue-next/issues/3887

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

https://developer.chrome.com/docs/css-ui/scrollbar-styling?hl=zh-cn  
chrome在121支持了scrollbar-width和scrollbar-color， 这两个属性原来是配置给firefox的样式。


官网1.9.1：

<img width="951" alt="windows-chrome-table-old" src="https://github.com/Tencent/tdesign-common/assets/13745660/34ac5e2e-b790-416b-a8c2-9fd130c7ba35">


<img width="396" alt="windows-chrome-date-old" src="https://github.com/Tencent/tdesign-common/assets/13745660/86f815a8-6d45-4ae2-9e3c-450436682f19">


修复后：

<img width="963" alt="windows-chrome-table-fix" src="https://github.com/Tencent/tdesign-common/assets/13745660/09053402-1cc9-49fd-abd5-a003af3f8e62">

<img width="401" alt="windows-chrome-date-fix" src="https://github.com/Tencent/tdesign-common/assets/13745660/27e74d54-e236-4e04-9af2-4f41a4aa0315">




### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): windows chrome滚动条样式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
