### PR TITLE
fix(ConfigProvider): tooltip about i18n support question

### DIFF
--- a/docs/web/api/config-provider.en-US.md
+++ b/docs/web/api/config-provider.en-US.md
@@ -25,6 +25,8 @@ If you want to contribute more language packs, please refer to [How to add a lan
 
 {{ global }}
 
+> Attention! When you use esm to import other components, make sure to import ConfigProvider with the corresponding esm version as well. Otherwise, there may be an issue with the language pack not taking effect.
+
 ### Pagination 
 
 {{ pagination }}

--- a/docs/web/api/config-provider.md
+++ b/docs/web/api/config-provider.md
@@ -25,7 +25,7 @@ TDesign 支持国际化/多语言配置，目前支持的语言包括:
 
 {{ global }}
 
-> 注意！当你使用 esm 引入的时候 `ConfigProvider` 也需要为对应的 esm 版本，否则会出现语言包不生效的问题。
+> 注意！当你使用 esm 引入了其他组件的时候 `ConfigProvider` 也需要为对应的 esm 版本的引入，否则会出现语言包不生效的问题。
 
 ### Pagination 分页
 

--- a/docs/web/api/config-provider.md
+++ b/docs/web/api/config-provider.md
@@ -25,6 +25,8 @@ TDesign 支持国际化/多语言配置，目前支持的语言包括:
 
 {{ global }}
 
+> 注意！当你使用 esm 引入的时候 `ConfigProvider` 也需要为对应的 esm 版本，否则会出现语言包不生效的问题。
+
 ### Pagination 分页
 
 {{ pagination }}


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

使用部分引入时，如果 ConfigProvider 与引入组件不是同一个模块下时无法激活语言包配置。

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
