### PR TITLE
fix(breadcrumb-item): 修复hover移出时过渡效果丢失

### DIFF
--- a/style/web/components/breadcrumb/_index.less
+++ b/style/web/components/breadcrumb/_index.less
@@ -192,6 +192,7 @@
       max-width: @breadcrumb-inner-max-width-default;
       display: flex;
       align-items: center;
+      transition: color @anim-duration-base linear;
 
       &-text {
         .t-overflow;
@@ -199,7 +200,6 @@
 
       &:hover {
         color: @breadcrumb-text-color-hover;
-        transition: color @anim-duration-base linear;
         cursor: pointer;
       }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 💡 需求背景和解决方案
breadcrumb-item的transition样式指定到了hover里，导致之后hover进入时有color过渡，但移出时color没有过渡

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- fix(BreadcrumbItem): 修复hover移出时过渡效果丢失

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
