### PR TITLE
fix/web/(menu-item): 修复渲染为a标签时没有文本溢出和collapsed时点击范围问题、icon被压缩问题

### DIFF
--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -370,6 +370,7 @@ a.@{prefix}-menu__item {
     .t-icon {
       width: 20px;
       height: 20px;
+      flex-shrink: 0;
     }
 
     .@{prefix}-fake-arrow {

--- a/style/web/components/menu/_index.less
+++ b/style/web/components/menu/_index.less
@@ -147,6 +147,7 @@ a.@{prefix}-menu__item {
         justify-content: center;
 
         .@{prefix}-menu__item-link {
+          margin-left: 0;
           opacity: 0;
           content: "";
           position: absolute;
@@ -567,6 +568,9 @@ a.@{prefix}-menu__item {
 
       &.@{prefix}-menu__item-link {
         color: unset;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
 
         &::before {
           content: "";


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 💡 需求背景和解决方案
![image](https://github.com/Tencent/tdesign-common/assets/29250685/2a5c4f24-4326-4fd0-a359-cf4779fd6b50)

![image](https://github.com/Tencent/tdesign-common/assets/29250685/67ae4f7f-9ee1-4d0c-8937-d08f8e02dce8)


### 📝 更新日志
- fix/web/(menu-item): 修复渲染为a标签时没有文本溢出的问题、collapsed时a标签覆盖范围未铺满按钮的问题
- fix/web/(menu-item): 文本溢出时icon被压缩大小的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
