### PR TITLE
fix(Select): 避免 Select 组件下拉选项 t-is-checked 样式覆盖已禁用样式

### DIFF
--- a/style/web/components/select/_index.less
+++ b/style/web/components/select/_index.less
@@ -210,7 +210,7 @@
   font: @select-font-s;
 }
 
-.@{prefix}-select-option.@{prefix}-is-selected {
+.@{prefix}-select-option.@{prefix}-is-selected:not(.@{prefix}-is-disabled) {
   color: @select-selected-color;
   background-color: @select-selected-bg-color;
   transition: all @anim-duration-base linear;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<https://github.com/Tencent/tdesign-vue/issues/3168>

### 💡 需求背景和解决方案

<img width="390" alt="image" src="https://github.com/Tencent/tdesign-vue/assets/3166782/0d9f00fe-4673-4930-bb29-3194d6d2eb53">

从 DevTools 上看，`.t-select-option.t-is-disabled` 样式有单独定义，但是优先级低于 `.t-select-option.t-is-selected`，导致字体颜色/背景色都被选中状态样式覆盖了


### 📝 更新日志

- fix(Select): 避免 Select 组件下拉选项 t-is-checked 样式覆盖已禁用样式

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
