### PR TITLE
fix: RangeInput & Input style fixes

### DIFF
--- a/style/web/components/input/_mixin.less
+++ b/style/web/components/input/_mixin.less
@@ -98,7 +98,6 @@
       text-align: center;
       display: flex;
       align-items: center;
-      font-size: @font-size-base;
     }
 
     & > .@{prefix}-input__@{position}-icon {

--- a/style/web/components/range-input/_index.less
+++ b/style/web/components/range-input/_index.less
@@ -60,6 +60,11 @@
       border-radius: @border-radius-small;
     }
 
+    // label 文字不换行
+    & > .@{prefix}-input__prefix {
+      white-space: nowrap;
+    }
+
     .@{prefix}-input {
       padding: @range-input-inner-padding;
       height: 100%;

--- a/style/web/components/range-input/_index.less
+++ b/style/web/components/range-input/_index.less
@@ -60,9 +60,9 @@
       border-radius: @border-radius-small;
     }
 
-    // label 文字不换行
+    // 避免 label 文字被容器内其他元素挤压导致过早换行
     & > .@{prefix}-input__prefix {
-      white-space: nowrap;
+      flex-shrink: 0;
     }
 
     .@{prefix}-input {

--- a/style/web/components/range-input/_var.less
+++ b/style/web/components/range-input/_var.less
@@ -34,7 +34,7 @@
 @range-input-extra-color-error: @error-color;
 
 // 间距
-@range-input-padding-default: @comp-paddingTB-xs @comp-paddingLR-s @comp-paddingTB-xs @comp-paddingLR-xs;
+@range-input-padding-default: @comp-paddingTB-xs @comp-paddingLR-s @comp-paddingTB-xs @comp-paddingLR-s;
 @range-input-status-position-right: calc(0px - @comp-margin-xxxl);
 @range-input-inner-gap: @comp-margin-s;
 @range-input-inner-padding: 0 @comp-paddingLR-xs;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<https://github.com/TDesignOteam/tdesign-api/pull/278>

### 💡 需求背景和解决方案

为 `RangeInputPopup` / `DatePicker` / `DateRangePicker` 添加 `label` 属性支持的前置样式修复

### 📝 更新日志

- fix(range-input): 修复左侧文本换行问题 & 对齐水平 padding 大小

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
