### PR TITLE
feat(collapse): collapse-pannel上的border-less样式生效

### DIFF
--- a/style/web/components/collapse/_index.less
+++ b/style/web/components/collapse/_index.less
@@ -65,6 +65,17 @@
   &__wrapper {
     overflow: hidden;
 
+    &.@{prefix}--border-less {
+      .@{collapse-panel-cls}__header {
+        border-bottom: none;
+      }
+
+      .@{collapse-panel-cls}__body {
+        background: @bg-color-container;
+        border: none;
+      }
+    }
+
     .@{collapse-panel-cls}__header {
       padding: @collapse-panel-header-padding;
       border-bottom: @collapse-border-size;

--- a/style/web/components/collapse/_index.less
+++ b/style/web/components/collapse/_index.less
@@ -65,7 +65,7 @@
   &__wrapper {
     overflow: hidden;
 
-    &.@{prefix}--border-less {
+    &.@{prefix}--borderless {
       .@{collapse-panel-cls}__header {
         border-bottom: none;
       }


### PR DESCRIPTION
web-components 下不使用 isLightDOM 就可以让 borderLess 的样式生效

isLightDOM 有其他副作用