### PR TITLE
fix: time format only support HH:mm:ss

### DIFF
--- a/js/date-picker/utils.ts
+++ b/js/date-picker/utils.ts
@@ -428,9 +428,9 @@ export function flagActive(data: any[], { ...args }: any) {
 
 // extract time format from a completed date format 'YYYY-MM-DD HH:mm' -> 'HH:mm'
 export function extractTimeFormat(dateFormat: string = '') {
-  const res = dateFormat.match(/(a\s)?h{1,2}(:m{1,2})?(:s{1,2})?(\sa)?/i);
-  if (!res) return null;
-  return res[0];
+  return dateFormat
+    .replace(/\W?Y{2,4}|\W?D{1,2}|\W?Do|\W?d{1,4}|\W?M{1,4}|\W?y{2,4}/g, '')
+    .trim();
 }
 
 /**

--- a/test/unit/date-picker/utils.test.js
+++ b/test/unit/date-picker/utils.test.js
@@ -1,0 +1,20 @@
+import { extractTimeFormat } from '../../../js/date-picker/utils';
+
+describe('utils', () => {
+  describe(' extractTimeFormat', () => {
+    it('YYYY-MM-DD HH:mm:ss', () => {
+      const res = extractTimeFormat('YYYY-MM-DD HH:mm:ss');
+      expect(res).toBe('HH:mm:ss');
+    });
+
+    it('YYYY-MM-DD HH时mm分ss秒', () => {
+      const res = extractTimeFormat('YYYY-MM-DD HH时mm分ss秒');
+      expect(res).toBe('HH时mm分ss秒');
+    });
+
+    it('YYYY-MM-DD HH时mm分ss秒SSS毫秒', () => {
+      const res = extractTimeFormat('YYYY-MM-DD HH时mm分ss秒SSS毫秒');
+      expect(res).toBe('HH时mm分ss秒SSS毫秒');
+    });
+  });
+});


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
日期选择器开启时间选择，格式化仅支持 HH:mm 格式，更换为HH时mm分ss秒格式时显示错误

### 📝 更新日志

fix(DatePicker): time format only support HH:mm:ss

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
