### PR TITLE
fix(tree): 匹配节点值`value`为`0` 时，不能正确匹配的问题

### DIFF
--- a/js/tree/tree-store.ts
+++ b/js/tree/tree-store.ts
@@ -289,7 +289,7 @@ export class TreeStore {
     } else if (item instanceof TreeNode) {
       val = item.value;
     }
-    if (!val) {
+    if (!val && val !== 0) {
       nodes = this.nodes.slice(0);
     } else {
       const node = this.getNode(val);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

`t-tree` 为`t-cascader`的上游组件。

在  close https://github.com/Tencent/tdesign-vue-next/issues/4641 中提到: `t-cascader` 在单选模式下，value=0 则默认选中第一个item,是因为这里当 `val=0` 时 `!val=true` 。则丧失了原节点数据匹配 `0` 数据节点的机会。

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree): 匹配节点值`value`为`0` 时，不能正确匹配的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
