### PR TITLE
feat: lodash-es instead of lodash

### DIFF
--- a/js/color-picker/gradient.ts
+++ b/js/color-picker/gradient.ts
@@ -1,5 +1,4 @@
-import isString from 'lodash/isString';
-import isNull from 'lodash/isNull';
+import { isString, isNull } from 'lodash-es';
 /* eslint-disable no-param-reassign */
 /**
  * 用于反解析渐变字符串为对象

--- a/js/date-picker/format.ts
+++ b/js/date-picker/format.ts
@@ -1,4 +1,4 @@
-import isString from 'lodash/isString';
+import { isString } from 'lodash-es';
 import dayjs from 'dayjs';
 import isoWeeksInYear from 'dayjs/plugin/isoWeeksInYear';
 import isLeapYear from 'dayjs/plugin/isLeapYear';

--- a/js/date-picker/utils.ts
+++ b/js/date-picker/utils.ts
@@ -1,4 +1,4 @@
-import isFunction from 'lodash/isFunction';
+import { isFunction, chunk } from 'lodash-es';
 import dayjs from 'dayjs';
 import dayJsIsBetween from 'dayjs/plugin/isBetween';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
@@ -7,7 +7,6 @@ import localeData from 'dayjs/plugin/localeData';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import chunk from 'lodash/chunk';
 import { parseToDayjs } from './format';
 
 dayjs.extend(weekOfYear);

--- a/js/input-number/large-number.ts
+++ b/js/input-number/large-number.ts
@@ -1,6 +1,4 @@
-import isString from 'lodash/isString';
-import isNumber from 'lodash/isNumber';
-import isObject from 'lodash/isObject';
+import { isString, isNumber, isObject } from 'lodash-es';
 import log from '../log/log';
 
 export type InputNumberDecimalPlaces = number | { enableRound: boolean, places: number };

--- a/js/input-number/number.ts
+++ b/js/input-number/number.ts
@@ -1,7 +1,5 @@
-import isUndefined from 'lodash/isUndefined';
+import { isUndefined, isString, isNumber } from 'lodash-es';
 /** 普通数相关方法 */
-import isString from 'lodash/isString';
-import isNumber from 'lodash/isNumber';
 import {
   compareNumber,
   formatENumber,

--- a/js/slider/utils.ts
+++ b/js/slider/utils.ts
@@ -1,4 +1,4 @@
-import isString from 'lodash/isString';
+import { isString } from 'lodash-es';
 
 /**
  * 计算刻度区间值停止坐标

--- a/js/table/tree-store.ts
+++ b/js/table/tree-store.ts
@@ -1,9 +1,7 @@
-import isUndefined from 'lodash/isUndefined';
+import { isUndefined, get, set } from 'lodash-es';
 /* eslint-disable class-methods-use-this */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-use-before-define */
-import get from 'lodash/get';
-import set from 'lodash/set';
 import { isRowSelectedDisabled } from './utils';
 import { PrimaryTableCol, TableRowState, TableRowValue, TableRowData } from './types';
 import log from '../log';

--- a/js/table/utils.ts
+++ b/js/table/utils.ts
@@ -1,6 +1,4 @@
-import isFunction from 'lodash/isFunction';
-import isNumber from 'lodash/isNumber';
-import get from 'lodash/get';
+import { isFunction, isNumber, get } from 'lodash-es';
 import { BaseTableCol } from './types';
 
 export function filterDataByIds(

--- a/js/tree-v1/tree-node-model.ts
+++ b/js/tree-v1/tree-node-model.ts
@@ -1,8 +1,4 @@
-import isUndefined from 'lodash/isUndefined';
-import isBoolean from 'lodash/isBoolean';
-import pick from 'lodash/pick';
-import omit from 'lodash/omit';
-import get from 'lodash/get';
+import { isUndefined, isBoolean, pick, omit } from 'lodash-es';
 import { TreeNode } from './tree-node';
 import { OptionData } from '../common';
 import {

--- a/js/tree-v1/tree-node.ts
+++ b/js/tree-v1/tree-node.ts
@@ -1,10 +1,4 @@
-import isNull from 'lodash/isNull';
-import isFunction from 'lodash/isFunction';
-import isNumber from 'lodash/isNumber';
-import uniqueId from 'lodash/uniqueId';
-import isBoolean from 'lodash/isBoolean';
-import isNil from 'lodash/isNil';
-import get from 'lodash/get';
+import { isNull, isFunction, isNumber, uniqueId, isBoolean, isNil, get } from 'lodash-es';
 import { TreeStore } from './tree-store';
 import {
   TreeNodeValue,

--- a/js/tree-v1/tree-store.ts
+++ b/js/tree-v1/tree-store.ts
@@ -1,10 +1,4 @@
-import isArray from 'lodash/isArray';
-import isFunction from 'lodash/isFunction';
-import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
-import difference from 'lodash/difference';
-import camelCase from 'lodash/camelCase';
-import isPlainObject from 'lodash/isPlainObject';
+import { isArray, isFunction, isNumber, isString, difference, camelCase, isPlainObject } from 'lodash-es';
 import mitt from 'mitt';
 
 import { TreeNode } from './tree-node';

--- a/js/tree/tree-node-model.ts
+++ b/js/tree/tree-node-model.ts
@@ -1,7 +1,4 @@
-import isUndefined from 'lodash/isUndefined';
-import isBoolean from 'lodash/isBoolean';
-import omit from 'lodash/omit';
-import get from 'lodash/get';
+import { isUndefined, isBoolean, omit, get } from 'lodash-es';
 import { TreeNode } from './tree-node';
 import { OptionData } from '../common';
 import {

--- a/js/tree/tree-node.ts
+++ b/js/tree/tree-node.ts
@@ -1,10 +1,4 @@
-import isNull from 'lodash/isNull';
-import isFunction from 'lodash/isFunction';
-import isNumber from 'lodash/isNumber';
-import uniqueId from 'lodash/uniqueId';
-import isBoolean from 'lodash/isBoolean';
-import isNil from 'lodash/isNil';
-import get from 'lodash/get';
+import { isNull, isFunction, isNumber, uniqueId, isBoolean, isNil, get } from 'lodash-es';
 import { TreeStore } from './tree-store';
 import {
   TreeNodeValue,

--- a/js/tree/tree-store.ts
+++ b/js/tree/tree-store.ts
@@ -1,10 +1,4 @@
-import isArray from 'lodash/isArray';
-import isFunction from 'lodash/isFunction';
-import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
-import difference from 'lodash/difference';
-import camelCase from 'lodash/camelCase';
-import isPlainObject from 'lodash/isPlainObject';
+import { isArray, isFunction, isNumber, isString, difference, camelCase, isPlainObject } from 'lodash-es';
 import mitt from 'mitt';
 
 import { TreeNode, privateKey } from './tree-node';

--- a/js/upload/main.ts
+++ b/js/upload/main.ts
@@ -1,5 +1,5 @@
-import isFunction from 'lodash/isFunction';
-import isNumber from 'lodash/isNumber';
+import { isFunction } from 'lodash-es';
+import { isNumber } from 'lodash-es';
 /* eslint-disable no-param-reassign */
 import { getCurrentDate, isOverSizeLimit } from './utils';
 import xhr from './xhr';

--- a/js/upload/main.ts
+++ b/js/upload/main.ts
@@ -1,5 +1,4 @@
-import { isFunction } from 'lodash-es';
-import { isNumber } from 'lodash-es';
+import { isFunction, isNumber } from 'lodash-es';
 /* eslint-disable no-param-reassign */
 import { getCurrentDate, isOverSizeLimit } from './utils';
 import xhr from './xhr';

--- a/js/upload/xhr.ts
+++ b/js/upload/xhr.ts
@@ -1,4 +1,4 @@
-import isFunction from 'lodash/isFunction';
+import { isFunction } from 'lodash-es';
 /* eslint-disable no-param-reassign */
 import log from '../log/log';
 import { UploadFile, XhrOptions } from './types';

--- a/js/utils/calcTextareaHeight.ts
+++ b/js/utils/calcTextareaHeight.ts
@@ -1,4 +1,4 @@
-import isNull from 'lodash/isNull';
+import { isNull } from 'lodash-es';
 import { calculateNodeSize } from './helper';
 
 type CalculateStyleType = {

--- a/js/utils/helper.ts
+++ b/js/utils/helper.ts
@@ -1,8 +1,4 @@
-import isString from 'lodash/isString';
-import isNull from 'lodash/isNull';
-import isUndefined from 'lodash/isUndefined';
-import isNumber from 'lodash/isNumber';
-import isArray from 'lodash/isArray';
+import { isString, isNull, isUndefined, isNumber, isArray } from 'lodash-es';
 
 export function omit(obj: object, fields: string[]): object {
   const shallowCopy = {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-flow": "^7.12.1",
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.0.3",
-    "@types/lodash": "4.17.13",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/experimental-utils": "^2.24.0",
@@ -80,7 +80,7 @@
     }
   },
   "dependencies": {
-    "lodash": "^4.17.15",
+    "lodash-es": "^4.17.21",
     "mitt": "^3.0.0",
     "tinycolor2": "^1.4.2"
   },

--- a/test/script/generate-demo-test.js
+++ b/test/script/generate-demo-test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const camelCase = require('lodash/camelCase');
-const upperFirst = require('lodash/upperFirst');
+const { camelCase } = require('lodash-es');
+const { upperFirst } = require('lodash-es');
 
 function resolveCwd(...args) {
   args.unshift(process.cwd());


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### issue

https://github.com/Tencent/tdesign-vue-next/issues/4961

### 💡 需求背景和解决方案

1. lodash-es instead of lodash

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refractor: lodash-es instead of lodash

- [x] 本条 PR 不需要纳入 Changelog
