### PR TITLE
fix(table): filter-control `Popup` arrow rendering error in `top-right` state

### DIFF
--- a/style/web/components/table/_index.less
+++ b/style/web/components/table/_index.less
@@ -63,6 +63,10 @@
   background-color: @table-bg;
   position: relative;
 
+  .@{prefix}-popup[data-popper-placement^="top"] .@{prefix}-popup__arrow {
+    bottom: calc(-@popup-arrow-width / 2);
+  }
+
   &:focus-visible {
     outline: none;
   }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
可能相关的 issue : https://github.com/Tencent/tdesign-common/pull/1347 、 https://github.com/Tencent/tdesign-common/pull/1337

这两个 pr 提到这个问题，看着原将此修复应用到 `Popup` ，后考虑因 `Popup` 被应用的上层组件太多，影响范围太大，则将其应修改分发到每个上次应用组件内进行修复。

当前先将此修复应用到 `Table` 内，如发现多处上层应用组件均发生此类问题，或此修复导致 `Table` 内应用其他包含 `Popup` 组件时产生问题（目前进行测试没有发生问题）再考虑进行其他方案修复。

### 💡 需求背景和解决方案
![image](https://github.com/user-attachments/assets/45495c26-f31d-41a7-a4fd-62f040835742)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 修复筛选控件弹窗中 `top-right` 状态下箭头渲染错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
