### PR TITLE
fix(color-picker): improve gradient color parsing and validation

### DIFF
--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -441,8 +441,12 @@ export class Color {
     const isGradientColor1 = Color.isGradientColor(color1);
     const isGradientColor2 = Color.isGradientColor(color2);
     if (isGradientColor1 && isGradientColor2) {
-      const gradientColor1 = gradientColors2string(parseGradientString(color1) as GradientColors);
-      const gradientColor2 = gradientColors2string(parseGradientString(color2) as GradientColors);
+      const gradientStr1 = parseGradientString(color1);
+      const gradientStr2 = parseGradientString(color2);
+      if (!gradientStr1 || !gradientStr2) return false;
+
+      const gradientColor1 = gradientColors2string(gradientStr1);
+      const gradientColor2 = gradientColors2string(gradientStr2);
       return gradientColor1 === gradientColor2;
     }
     if (!isGradientColor1 && !isGradientColor2) {

--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -70,8 +70,8 @@ export const genId = () => (1 + Math.random() * 4294967295).toString(16);
  * @param color
  * @returns
  */
-export const genGradientPoint = (left: number, color: string): GradientColorPoint => ({
-  id: genId(),
+export const genGradientPoint = (left: number, color: string, id?: string): GradientColorPoint => ({
+  id: id || genId(),
   left,
   color,
 });
@@ -121,11 +121,11 @@ export class Color {
     if (gradientColors) {
       this.isGradient = true;
       const object = gradientColors as GradientColors;
-      const points = object.points.map((c) => genGradientPoint(c.left, c.color));
+      const points = object.points.map((c, index) => genGradientPoint(c.left, c.color, this.gradientStates.colors[index]?.id));
       this.gradientStates = {
         colors: points,
         degree: object.degree,
-        selectedId: points[0]?.id || null,
+        selectedId: this.gradientStates.selectedId || points[0]?.id || null,
       };
       this.gradientStates.css = this.linearGradient;
       colorInput = this.gradientSelectedPoint?.color;

--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -286,6 +286,20 @@ export class Color {
     };
   }
 
+  getFormattedColor(format: string, enableAlpha: boolean) {
+    if (this.isGradient) return this.linearGradient;
+    const alphaFormats: Record<string, string> = {
+      HEX: 'HEX8',
+      RGB: 'RGBA',
+      HSL: 'HSLA',
+      HSV: 'HSVA',
+    };
+    const finalFormat = (
+      enableAlpha && alphaFormats[format] ? alphaFormats[format] : format
+    ) as keyof ReturnType<Color['getFormatsColorMap']>;
+    return this.getFormatsColorMap()[finalFormat];
+  }
+
   updateCurrentGradientColor() {
     const { isGradient, gradientColors, gradientSelectedId } = this;
     const { length } = gradientColors;

--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -100,12 +100,16 @@ export class Color {
   }
 
   update(input: string) {
-    if (input === this.originColor) {
-      return;
-    }
+    if (input === this.originColor) return;
     const gradientColors = parseGradientString(input);
+
     if (this.isGradient && !gradientColors) {
-      // 处理gradient模式下切换不同格式时的交互问题，输入的不是渐变字符串才使用当前处理
+      /* 这里是针对渐变模式下，修改某个位置点的色值情况
+
+       「Tip」
+        - 为了避免有时外界从渐变切换到单色模式，存在缓存问题
+          需要手动设置 `color.isGradient = false` 进行同步
+        - 特定场景下，也可以直接创建新实例 `new Color` 进行覆盖 */
       const colorHsv = tinyColor(input).toHsv();
       this.states = colorHsv;
       this.updateCurrentGradientColor();

--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -1,5 +1,6 @@
 import tinyColor from 'tinycolor2';
 import { cmykInputToColor, rgb2cmyk } from './cmyk';
+import { ALPHA_FORMATS } from './constants';
 import {
   parseGradientString, GradientColors, GradientColorPoint, isGradientColor
 } from './gradient';
@@ -288,14 +289,8 @@ export class Color {
 
   getFormattedColor(format: string, enableAlpha: boolean) {
     if (this.isGradient) return this.linearGradient;
-    const alphaFormats: Record<string, string> = {
-      HEX: 'HEX8',
-      RGB: 'RGBA',
-      HSL: 'HSLA',
-      HSV: 'HSVA',
-    };
     const finalFormat = (
-      enableAlpha && alphaFormats[format] ? alphaFormats[format] : format
+      enableAlpha && ALPHA_FORMATS[format] ? ALPHA_FORMATS[format] : format
     ) as keyof ReturnType<Color['getFormatsColorMap']>;
     return this.getFormatsColorMap()[finalFormat];
   }

--- a/js/color-picker/constants.ts
+++ b/js/color-picker/constants.ts
@@ -60,7 +60,15 @@ export const DEFAULT_SYSTEM_SWATCH_COLORS = [
 ];
 
 // 非透明色格式化类型
-export const FORMATS = ['HEX', 'RGB', 'HSL', 'HSV', 'CMYK', 'CSS'];
+export const FORMATS = ['HEX', 'RGB', 'HSL', 'HSV', 'CMYK', 'CSS'] as const;
+
+// 透明色格式化类型映射
+export const ALPHA_FORMATS: Record<string, string> = {
+  HEX: 'HEX8',
+  RGB: 'RGBA',
+  HSL: 'HSLA',
+  HSV: 'HSVA',
+};
 
 // saturation-panel default rect
 export const SATURATION_PANEL_DEFAULT_WIDTH = 230;

--- a/js/color-picker/gradient.ts
+++ b/js/color-picker/gradient.ts
@@ -186,14 +186,14 @@ const sideCornerDegreeMap = {
   right: 90,
   bottom: 180,
   left: 270,
-  'top left': 225,
-  'left top': 225,
-  'top right': 135,
-  'right top': 135,
-  'bottom left': 315,
-  'left bottom': 315,
-  'bottom right': 45,
-  'right bottom': 45,
+  'top left': 315,
+  'left top': 315,
+  'top right': 45,
+  'right top': 45,
+  'bottom left': 225,
+  'left bottom': 225,
+  'bottom right': 135,
+  'right bottom': 135,
 };
 
 /**
@@ -201,30 +201,38 @@ const sideCornerDegreeMap = {
  * @param input
  * @returns
  */
-export const parseGradientString = (input: string): GradientColors | boolean => {
+export const parseGradientString = (input: string): GradientColors | false => {
   const match = isGradientColor(input);
-  if (!match) {
-    return false;
-  }
+  if (!match) return false;
+
   const gradientColors: GradientColors = {
     points: [],
     degree: 0,
   };
 
   const result: ParseGradientResult = parseGradient(REGEXP_LIB, match[1]);
-  if (result.original.trim() !== match[1].trim()) {
-    return false;
-  }
-  const points: GradientColorPoint[] = result.colorStopList.map(({ color, position }) => {
-    const point = Object.create(null);
-    point.color = tinyColor(color).toRgbString();
-    point.left = parseFloat(position);
-    return point;
-  });
+  if (result.original.trim() !== match[1].trim()) return false;
+
+  const points: GradientColorPoint[] = result.colorStopList.map(
+    ({ color, position }, index, array) => {
+      const point = Object.create(null);
+      point.color = tinyColor(color).toRgbString();
+
+      let left = parseFloat(position);
+      if (Number.isNaN(left)) {
+        left = (index / (array.length - 1)) * 100;
+      }
+
+      point.left = left;
+      return point;
+    }
+  );
   gradientColors.points = points;
+
   let degree = parseInt(result.angle, 10);
   if (Number.isNaN(degree)) {
-    degree = sideCornerDegreeMap[result.sideCorner as keyof typeof sideCornerDegreeMap] || 90;
+    // 如果角度不存在，使用 CSS 渐变的默认逻辑（180 deg）
+    degree = sideCornerDegreeMap[result.sideCorner as keyof typeof sideCornerDegreeMap] || 180;
   }
   gradientColors.degree = degree;
 

--- a/js/color-picker/gradient.ts
+++ b/js/color-picker/gradient.ts
@@ -231,7 +231,8 @@ export const parseGradientString = (input: string): GradientColors | false => {
 
   let degree = parseInt(result.angle, 10);
   if (Number.isNaN(degree)) {
-    // 如果角度不存在，使用 CSS 渐变的默认逻辑（180 deg）
+    /* 如果角度不存在，使用 CSS 渐变的默认逻辑（180 deg）
+       https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_images/Using_CSS_gradients */
     degree = sideCornerDegreeMap[result.sideCorner as keyof typeof sideCornerDegreeMap] || 180;
   }
   gradientColors.degree = degree;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

#### 变动说明

- 修复直接断言类型 `as GradientColors`，导致实际传入 `false` 时，后续逻辑报错。
- 修复角度映射表 `sideCornerDegreeMap` 数值错误的问题。 
![image](https://github.com/user-attachments/assets/daeebf1f-bbb6-4424-8b10-1827863a199b)

（左边是预期合理的，右边是线上错误的映射，可以看到上下两个渐变颜色角度不同）

- 优化 CSS 渐变字符串解析逻辑，当用户不传入颜色位置时，会根据点的数量自动计算位置，进行平均分布。
  - 即输入 `linear-gradient(blue, pink)` 会被格式化为 `linear-gradient(180deg,rgb(0, 0, 255) 0%,rgb(255, 192, 203) 100%)`，避免原先产生 `NaN` 的情况。
  
![image](https://github.com/user-attachments/assets/95492c72-d495-4bad-8e8d-07570968ab27)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ColorPicker): 修复 CSS 渐变角度映射错误，并实现自动计算渐变点的位置

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
