### PR TITLE
refactor(color-picker): optimize color format conversion

### DIFF
--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -4,7 +4,7 @@ import { ALPHA_FORMAT_MAP } from './constants';
 import {
   parseGradientString, GradientColors, GradientColorPoint, isGradientColor
 } from './gradient';
-import type { BasicColorFormat, ColorFormat } from './types';
+import type { AlphaConvertibleFormat, ColorFormat } from './types';
 
 export interface ColorObject {
   alpha: number;
@@ -291,8 +291,8 @@ export class Color {
   getFormattedColor(format: ColorFormat, enableAlpha: boolean) {
     if (this.isGradient) return this.linearGradient;
     const finalFormat = (
-      enableAlpha && ALPHA_FORMAT_MAP[format as BasicColorFormat]
-        ? ALPHA_FORMAT_MAP[format as BasicColorFormat]
+      enableAlpha && format in ALPHA_FORMAT_MAP
+        ? ALPHA_FORMAT_MAP[format as AlphaConvertibleFormat]
         : format
     ) as keyof ReturnType<Color['getFormatsColorMap']>;
     return this.getFormatsColorMap()[finalFormat];

--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -1,9 +1,10 @@
 import tinyColor from 'tinycolor2';
 import { cmykInputToColor, rgb2cmyk } from './cmyk';
-import { ALPHA_FORMATS } from './constants';
+import { ALPHA_FORMAT_MAP } from './constants';
 import {
   parseGradientString, GradientColors, GradientColorPoint, isGradientColor
 } from './gradient';
+import type { BasicColorFormat, ColorFormat } from './types';
 
 export interface ColorObject {
   alpha: number;
@@ -287,10 +288,12 @@ export class Color {
     };
   }
 
-  getFormattedColor(format: string, enableAlpha: boolean) {
+  getFormattedColor(format: ColorFormat, enableAlpha: boolean) {
     if (this.isGradient) return this.linearGradient;
     const finalFormat = (
-      enableAlpha && ALPHA_FORMATS[format] ? ALPHA_FORMATS[format] : format
+      enableAlpha && ALPHA_FORMAT_MAP[format as BasicColorFormat]
+        ? ALPHA_FORMAT_MAP[format as BasicColorFormat]
+        : format
     ) as keyof ReturnType<Color['getFormatsColorMap']>;
     return this.getFormatsColorMap()[finalFormat];
   }

--- a/js/color-picker/constants.ts
+++ b/js/color-picker/constants.ts
@@ -1,4 +1,8 @@
-/** 常量 */
+import type {
+  AlphaColorFormat,
+  BasicColorFormat,
+  ColorInputProp,
+} from './types';
 
 // 最近使用颜色最大个数
 export const TD_COLOR_USED_COLORS_MAX_SIZE = 100; // 每行10个
@@ -59,18 +63,137 @@ export const DEFAULT_SYSTEM_SWATCH_COLORS = [
   '#033017',
 ];
 
-// 非透明色格式化类型
-export const FORMATS = ['HEX', 'RGB', 'HSL', 'HSV', 'CMYK', 'CSS'] as const;
+/**
+ * 非透明色格式化类型
+ */
+export const FORMATS: BasicColorFormat[] = [
+  'HEX',
+  'RGB',
+  'HSL',
+  'HSV',
+  'CMYK',
+  'CSS',
+] as const;
 
-// 透明色格式化类型映射
-export const ALPHA_FORMATS: Record<string, string> = {
+/**
+ * 透明色格式化类型映射
+ */
+export const ALPHA_FORMAT_MAP: Partial<
+  Record<BasicColorFormat, AlphaColorFormat>
+> = {
   HEX: 'HEX8',
   RGB: 'RGBA',
   HSL: 'HSLA',
   HSV: 'HSVA',
+} as const;
+
+/**
+ * 不同格式对应的输入框
+ */
+export const COLOR_FORMAT_INPUTS: Record<BasicColorFormat, ColorInputProp[]> = {
+  RGB: [
+    {
+      key: 'r',
+      min: 0,
+      max: 255,
+      type: 'inputNumber',
+    },
+    {
+      key: 'g',
+      min: 0,
+      max: 255,
+      type: 'inputNumber',
+    },
+    {
+      key: 'b',
+      min: 0,
+      max: 255,
+      type: 'inputNumber',
+    },
+  ],
+  HSV: [
+    {
+      key: 'h',
+      min: 0,
+      max: 360,
+      type: 'inputNumber',
+    },
+    {
+      key: 's',
+      min: 0,
+      max: 100,
+      type: 'inputNumber',
+    },
+    {
+      key: 'v',
+      min: 0,
+      max: 100,
+      type: 'inputNumber',
+    },
+  ],
+  HSL: [
+    {
+      key: 'h',
+      min: 0,
+      max: 360,
+      type: 'inputNumber',
+    },
+    {
+      key: 's',
+      min: 0,
+      max: 100,
+      type: 'inputNumber',
+    },
+    {
+      key: 'l',
+      min: 0,
+      max: 100,
+      type: 'inputNumber',
+    },
+  ],
+  CMYK: [
+    {
+      key: 'c',
+      min: 0,
+      max: 255,
+      type: 'inputNumber',
+    },
+    {
+      key: 'm',
+      min: 0,
+      max: 255,
+      type: 'inputNumber',
+    },
+    {
+      key: 'y',
+      min: 0,
+      max: 255,
+      type: 'inputNumber',
+    },
+    {
+      key: 'k',
+      min: 0,
+      max: 255,
+      type: 'inputNumber',
+    },
+  ],
+  CSS: [
+    {
+      key: 'css',
+      type: 'input',
+      flex: 3,
+    },
+  ],
+  HEX: [
+    {
+      key: 'hex',
+      type: 'input',
+      flex: 3,
+    },
+  ],
 };
 
-// saturation-panel default rect
+// 色板尺寸
 export const SATURATION_PANEL_DEFAULT_WIDTH = 230;
 export const SATURATION_PANEL_DEFAULT_HEIGHT = 168;
 export const SLIDER_DEFAULT_WIDTH = 186;

--- a/js/color-picker/constants.ts
+++ b/js/color-picker/constants.ts
@@ -1,5 +1,4 @@
 import type {
-  AlphaColorFormat,
   BasicColorFormat,
   ColorInputProp,
 } from './types';
@@ -66,7 +65,7 @@ export const DEFAULT_SYSTEM_SWATCH_COLORS = [
 /**
  * 非透明色格式化类型
  */
-export const FORMATS: BasicColorFormat[] = [
+export const FORMATS = [
   'HEX',
   'RGB',
   'HSL',
@@ -78,9 +77,7 @@ export const FORMATS: BasicColorFormat[] = [
 /**
  * 透明色格式化类型映射
  */
-export const ALPHA_FORMAT_MAP: Partial<
-  Record<BasicColorFormat, AlphaColorFormat>
-> = {
+export const ALPHA_FORMAT_MAP = {
   HEX: 'HEX8',
   RGB: 'RGBA',
   HSL: 'HSLA',

--- a/js/color-picker/format.ts
+++ b/js/color-picker/format.ts
@@ -1,6 +1,6 @@
 import Color from './color';
 import { ALPHA_FORMAT_MAP, COLOR_FORMAT_INPUTS, FORMATS } from './constants';
-import type { BasicColorFormat, ColorFormat } from './types';
+import type { AlphaConvertibleFormat, BasicColorFormat, ColorFormat } from './types';
 
 /**
  * 兜底处理用户传入的格式，例如：
@@ -8,7 +8,7 @@ import type { BasicColorFormat, ColorFormat } from './types';
  */
 export const initColorFormat = (format: ColorFormat, enableAlpha: boolean) => {
   if (enableAlpha && format in ALPHA_FORMAT_MAP) {
-    return ALPHA_FORMAT_MAP[format as BasicColorFormat];
+    return format in ALPHA_FORMAT_MAP ? ALPHA_FORMAT_MAP[format as AlphaConvertibleFormat] : format;
   }
   return format as BasicColorFormat;
 };
@@ -59,7 +59,11 @@ export const getColorFormatMap = (color: Color, type: 'encode' | 'decode') => {
 /**
  * 获取下拉框的格式选项
  */
-export const getColorFormatOptions = (enableAlpha: boolean) => (enableAlpha ? FORMATS.map((item) => ALPHA_FORMAT_MAP[item] || item) : FORMATS);
+export const getColorFormatOptions = (enableAlpha: boolean) => (
+  enableAlpha
+    ? FORMATS.map((item) => (item in ALPHA_FORMAT_MAP ? ALPHA_FORMAT_MAP[item as AlphaConvertibleFormat] : item))
+    : FORMATS
+);
 
 /**
  * 获取当前格式的输入框配置
@@ -75,7 +79,7 @@ export const getColorFormatInputs = (
      但在下一步会 push 一个代表透明度的输入框 */
   if (enableAlpha) {
     finalFormat = Object.keys(ALPHA_FORMAT_MAP).find(
-      (key) => ALPHA_FORMAT_MAP[key as BasicColorFormat] === format
+      (key) => key in ALPHA_FORMAT_MAP && ALPHA_FORMAT_MAP[key as AlphaConvertibleFormat] === format
     ) || format;
   } else {
     finalFormat = format;

--- a/js/color-picker/format.ts
+++ b/js/color-picker/format.ts
@@ -1,0 +1,103 @@
+import Color from './color';
+import { ALPHA_FORMAT_MAP, COLOR_FORMAT_INPUTS, FORMATS } from './constants';
+import type { BasicColorFormat, ColorFormat } from './types';
+
+/**
+ * 兜底处理用户传入的格式，例如：
+ * - 传入 `RGB`， 但 `enableAlpha` ，则返回 `RGBA`
+ */
+export const initColorFormat = (format: ColorFormat, enableAlpha: boolean) => {
+  if (enableAlpha && format in ALPHA_FORMAT_MAP) {
+    return ALPHA_FORMAT_MAP[format as BasicColorFormat];
+  }
+  return format as BasicColorFormat;
+};
+
+/**
+ * 获取不同格式的输入输出值
+ * - encode：将字符串转换为单独的颜色值，例如 `{r: 255, g: 255, b: 255}`
+ * - decode：获取完整的颜色字符串，例如 `rgb(255, 255, 255)`
+ */
+export const getColorFormatMap = (color: Color, type: 'encode' | 'decode') => {
+  if (type === 'encode') {
+    return {
+      HSV: color.getHsva(),
+      HSVA: color.getHsva(),
+      HSL: color.getHsla(),
+      HSLA: color.getHsla(),
+      RGB: color.getRgba(),
+      RGBA: color.getRgba(),
+      CMYK: color.getCmyk(),
+      CSS: {
+        css: color.css,
+      },
+      HEX: {
+        hex: color.hex,
+      },
+      HEX8: {
+        hex: color.hex8,
+      },
+    };
+  }
+
+  const object2color = (format: ColorFormat) => Color.object2color(color, format);
+  // decode
+  return {
+    HSV: object2color('HSV'),
+    HSVA: object2color('HSVA'),
+    HSL: object2color('HSL'),
+    HSLA: object2color('HSLA'),
+    RGB: object2color('RGB'),
+    RGBA: object2color('RGBA'),
+    CMYK: object2color('CMYK'),
+    CSS: color.css,
+    HEX: color.hex,
+    HEX8: color.hex8,
+  };
+};
+
+/**
+ * 获取下拉框的格式选项
+ */
+export const getColorFormatOptions = (enableAlpha: boolean) => (enableAlpha ? FORMATS.map((item) => ALPHA_FORMAT_MAP[item] || item) : FORMATS);
+
+/**
+ * 获取当前格式的输入框配置
+ */
+export const getColorFormatInputs = (
+  format: ColorFormat = 'RGB',
+  enableAlpha: boolean
+) => {
+  let finalFormat;
+
+  /* 为了减少 `ALPHA_FORMAT_MAP` 中的重复代码
+     `RGBA/HEX8/HSLA/HSVA` 会被转换为 `RGB/HEX/HSL/HSV` 后再匹配
+     但在下一步会 push 一个代表透明度的输入框 */
+  if (enableAlpha) {
+    finalFormat = Object.keys(ALPHA_FORMAT_MAP).find(
+      (key) => ALPHA_FORMAT_MAP[key as BasicColorFormat] === format
+    ) || format;
+  } else {
+    finalFormat = format;
+  }
+
+  if (!COLOR_FORMAT_INPUTS[finalFormat as BasicColorFormat]) return [];
+
+  const configs = [
+    ...(COLOR_FORMAT_INPUTS[finalFormat as BasicColorFormat]),
+  ];
+
+  // CMYK 格式不支持透明度
+  if (enableAlpha && format !== 'CMYK') {
+    configs.push({
+      type: 'inputNumber',
+      key: 'a',
+      min: 0,
+      max: 100,
+      format: (value: number) => `${value}%`,
+      flex: 1.15,
+    });
+  }
+
+  return configs;
+};

--- a/js/color-picker/index.ts
+++ b/js/color-picker/index.ts
@@ -1,4 +1,7 @@
 export * from './cmyk';
 export * from './color';
+export * from './constants';
 export * from './draggable';
+export * from './format';
 export * from './gradient';
+export * from './types';

--- a/js/color-picker/types.ts
+++ b/js/color-picker/types.ts
@@ -1,9 +1,28 @@
-export type BasicColorFormat = 'RGB' | 'HEX' | 'HSL' | 'HSV' | 'CMYK' | 'CSS';
+import { ALPHA_FORMAT_MAP, FORMATS } from './constants';
 
-export type AlphaColorFormat = 'RGBA' | 'HEX8' | 'HSLA' | 'HSVA';
+/**
+ * 非透明色类型
+ */
+export type BasicColorFormat = typeof FORMATS[number];
 
+/**
+ * 支持转为透明格式的非透明色类型
+ */
+export type AlphaConvertibleFormat = keyof typeof ALPHA_FORMAT_MAP;
+
+/**
+ * 透明色类型
+ */
+export type AlphaColorFormat = typeof ALPHA_FORMAT_MAP[AlphaConvertibleFormat];
+
+/**
+ * 完整的颜色格式类型
+ */
 export type ColorFormat = BasicColorFormat | AlphaColorFormat;
 
+/**
+ * 不同颜色格式对应的输入框配置
+ */
 export interface ColorInputProp {
   key: string;
   min?: number;

--- a/js/color-picker/types.ts
+++ b/js/color-picker/types.ts
@@ -1,0 +1,14 @@
+export type BasicColorFormat = 'RGB' | 'HEX' | 'HSL' | 'HSV' | 'CMYK' | 'CSS';
+
+export type AlphaColorFormat = 'RGBA' | 'HEX8' | 'HSLA' | 'HSVA';
+
+export type ColorFormat = BasicColorFormat | AlphaColorFormat;
+
+export interface ColorInputProp {
+  key: string;
+  min?: number;
+  max?: number;
+  type: 'input' | 'inputNumber';
+  flex?: number;
+  format?: Function;
+}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- 将 PC 三端一些通用的函数抽取放入 common 仓
- 优化 `ColorPicker` Format 下拉框显示的类型，开启 `enableAlpha` 时，将 options 转为对应的透明通道类型，避免选中异常
<img src="https://github.com/user-attachments/assets/014f9028-815d-4a08-bea6-248ebea4a49f" width="350px" />

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refactor(color-picker)：提取通用函数，优化透明通道下的颜色格式转换

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
