### PR TITLE
fix(Cascader): fix cascader text ellipsis padding 

### DIFF
--- a/style/web/components/cascader/_index.less
+++ b/style/web/components/cascader/_index.less
@@ -165,8 +165,6 @@
     }
 
     &--with-icon {
-
-      // padding: @cascader-item-padding-with-icon;
       .@{prefix}-checkbox__label,
       .@{prefix}-cascader__item-label {
         margin-right: 16px;

--- a/style/web/components/cascader/_index.less
+++ b/style/web/components/cascader/_index.less
@@ -96,11 +96,13 @@
     &.@{prefix}-size-s {
       height: @cascader-item-height-s;
       font: @cascader-font-s;
+      padding: @cascader-item-padding-s;
     }
 
     &.@{prefix}-size-l {
       height: @cascader-item-height-l;
       font: @cascader-font-l;
+      padding: @cascader-item-padding-l;
     }
 
     &.@{prefix}-is-disabled {
@@ -163,7 +165,12 @@
     }
 
     &--with-icon {
-      padding: @cascader-item-padding-with-icon;
+
+      // padding: @cascader-item-padding-with-icon;
+      .@{prefix}-checkbox__label,
+      .@{prefix}-cascader__item-label {
+        margin-right: 16px;
+      }
     }
 
     &--leaf {

--- a/style/web/components/cascader/_index.less
+++ b/style/web/components/cascader/_index.less
@@ -96,13 +96,11 @@
     &.@{prefix}-size-s {
       height: @cascader-item-height-s;
       font: @cascader-font-s;
-      padding: @cascader-item-padding-s;
     }
 
     &.@{prefix}-size-l {
       height: @cascader-item-height-l;
       font: @cascader-font-l;
-      padding: @cascader-item-padding-l;
     }
 
     &.@{prefix}-is-disabled {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. https://github.com/Tencent/tdesign-vue-next/issues/5346
-->
https://github.com/Tencent/tdesign-vue-next/issues/5346
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

Cascader的item里的左边距和右边距应该用t-cascader-item-with-icon统一控制
<img width="2281" alt="355b63b456ebe62cdbcf1a22809a09be" src="https://github.com/user-attachments/assets/9e554cc0-bb75-4c7c-ba4c-486c0c9657ec" />

当前在t-size-s/t-size-l<span>设置的内边距控制是不必的；


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
修复前后对比
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/2054222d-7534-4636-9434-0d69cab4d866" />

<img width="1163" alt="image" src="https://github.com/user-attachments/assets/1fb0c65d-bfe4-46a8-b11a-4e82ad0f1130" />



- fix(Cascader): 修复选项存在超长文字在大小尺寸下展示异常的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
