### PR TITLE
fix(cascader): ensure consistent margin for cascader component

### DIFF
--- a/style/web/components/cascader/_index.less
+++ b/style/web/components/cascader/_index.less
@@ -61,6 +61,7 @@
     box-sizing: content-box;
     padding: @cascader-menu-padding;
     background: @bg-color-container;
+    margin: 0;
 
     &.@{prefix}-size-l {
       padding: @cascader-menu-padding-l;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

NO

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

![image](https://github.com/user-attachments/assets/d25dcf6b-35d2-4521-8417-ad805868685e)

问题：
展开 Cascader 组件的选项面板，在未覆盖 ul 元素 margin 值的项目中，存在多余的 margin 需要被清除，以确保在任意项目中有统一的表现。

此问题在官方文档中 https://tdesign.tencent.com/vue-next/components/cascader 不易被发现，因为该文档项目重置了 ul 元素的 margin 值为 0。

```css
ul, dl, ol {
    margin: 0;
    padding: 0 0 0 1.2em;
    line-height: 22px;
}
```

解决方案：
参考 select 组件的选项面板 `.t-select__list` 样式，给 `.t-cascader__menu` 设置以下样式：

```css
margin: 0;
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(cascader): ensure consistent margin for cascader component

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
