### PR TITLE
fix(image-viewer): prevent modal collapse on image load error

### DIFF
--- a/style/web/components/image-viewer/_index.less
+++ b/style/web/components/image-viewer/_index.less
@@ -13,10 +13,8 @@
   border-radius: 4px;
   color: @image-viewer__image-text--error;
   cursor: inherit;
-  position: absolute;
 
   .@{prefix}-image-viewer__img-error-content {
-    position: absolute;
     height: 100%;
     width: 100%;
     display: flex;
@@ -119,9 +117,8 @@
   }
 
   .@{prefix}-image-viewer__modal-pic {
-    height: 0;
-    width: 0;
     position: absolute;
+    transform: translate(-50%, -50%);
     top: 50%;
     left: 50%;
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

Error Image 脱离文档流，导致没能把 Dialog 撑开

<img src="https://github.com/user-attachments/assets/3684d103-aa0e-4894-a5c1-6615e9b1c854"  width="500"/>

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ImageViewer): 当显示错误图片时，小窗口图片查看器尺寸异常

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
