### PR TITLE
fix(stringTemplate): 默认错误message显示0

### DIFF
--- a/js/utils/stringTemplate.ts
+++ b/js/utils/stringTemplate.ts
@@ -4,6 +4,15 @@
  * @param vars 取值的对象
  * @returns 替换后的字符串
  */
-export function template<T extends Record<string, string>>(str: string, vars: T): string {
-  return str.replace(/\${(.*?)}/g, (_, prop: string) => vars[prop.trim()] ?? '');
+type varsValue = string | number | string[]; // name(String)、min、max（Number），enums(string[])
+export function template<T extends Record<string, varsValue>>(
+  str: string,
+  vars: T
+): string {
+  return str.replace(/\${(.*?)}/g, (_, prop: string) => {
+    const value = vars[prop.trim()];
+    if (Array.isArray(value)) return value.join(',');
+
+    return value === 0 ? '0' : String(value || '');
+  });
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5602

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

背景:

当一个项目提供 min、max、len、enum，而又不提供默认错误信息，则默认信息的字符串模板为：

```
"max": "${name}字符长度不能超过 ${validate} 个字符，一个中文等于两个字符",
"min": "${name}字符长度不能少于 ${validate} 个字符，一个中文等于两个字符",
"len": "${name}字符长度必须是 ${validate}",
"enum": "${name}只能是${validate}等",
```
stringTemplate 的 template 方法的第二个参数 vars { name, validate }，实际要支持 min、min、len (Number)，enum（StringArray）

解决：
1. 修改函数返回值类型；
2. 支持 0

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
