### PR TITLE
feat(i18n): support second args is number

### DIFF
--- a/js/global-config/locale/en_US.ts
+++ b/js/global-config/locale/en_US.ts
@@ -10,7 +10,7 @@ export default {
     itemsPerPage: '{size} / page',
     jumpTo: 'Jump to',
     page: '',
-    total: 'no items | 1 item | {total} items',
+    total: 'no items | 1 item | {count} items',
   },
   cascader: {
     empty: 'Empty Data',

--- a/js/global-config/t.ts
+++ b/js/global-config/t.ts
@@ -1,4 +1,4 @@
-import { isFunction, isString } from 'lodash-es';
+import { isString } from 'lodash-es';
 
 /**
  * 复数规则判断函数
@@ -75,7 +75,7 @@ export function t<T>(pattern: T, ...args: any[]): string {
       const pluralParts = text.split('|').map((part) => part.trim());
 
       if (typeof count === 'number') {
-      // 使用 count 进行复数处理
+        // 使用 count 进行复数处理
         const pluralIndex = getPluralIndex(count);
 
         // 根据复数索引选择对应的文本
@@ -86,7 +86,7 @@ export function t<T>(pattern: T, ...args: any[]): string {
           text = pluralParts[pluralParts.length - 1];
         }
       } else {
-      // 如果没有 count，默认使用第一个选项
+        // 如果没有 count，默认使用第一个选项
         const [firstPart] = pluralParts;
         text = firstPart;
       }

--- a/js/global-config/t.ts
+++ b/js/global-config/t.ts
@@ -24,51 +24,79 @@ function getPluralIndex(count: number): number {
  * 1. 基本变量替换：
  *    t('Hello {name}', { name: 'World' }) // => 'Hello World'
  *
- * 2. 复数处理：
- *    t('no apples | one apple | {count} apples', { count: 0 }) // => 'no apples'
- *    t('no apples | one apple | {count} apples', { count: 1 }) // => 'one apple'
- *    t('no apples | one apple | {count} apples', { count: 5 }) // => '5 apples'
+ * 2. 复数处理（传入数字）：
+ *    t('no apples | one apple | {count} apples', 0) // => 'no apples'
+ *    t('no apples | one apple | {count} apples', 1) // => 'one apple'
+ *    t('no apples | one apple | {count} apples', 5) // => '5 apples'
  *
  * 3. 复合使用：
- *    t('no items found | found {count} item | found {count} items', { count: 3 }) // => 'found 3 items'
- *
+ *    t('no items found | found {count} item | found {count} items', 3, { count: 3 }) // => 'found 3 items'
+ */
+
+// 类型重载定义
+export function t(pattern: string): string;
+export function t(pattern: string, data: Record<string, any>): string;
+export function t(pattern: string, count: number): string;
+export function t(pattern: string, count: number, data: Record<string, any>): string;
+export function t<T>(pattern: T): string;
+
+/**
  * @param pattern 文本模式，可以是字符串、函数或其他类型
- * @param args 参数列表
+ * @param args 参数列表，支持 (count: number) 或 (count: number, data: object) 或 (data: object)
  * @returns 处理后的文本
  */
-export const t = function t<T>(pattern: T, ...args: any[]) {
-  const [data] = args;
-
+export function t<T>(pattern: T, ...args: any[]): string {
   if (isString(pattern)) {
     let text = pattern as string;
+    let count: number | undefined;
+    let data: Record<string, any> = {};
+
+    // 解析参数
+    if (args.length > 0) {
+      const [firstArg, secondArg] = args;
+
+      if (typeof firstArg === 'number') {
+      // 第一个参数是数字，表示 count
+        count = firstArg;
+        if (secondArg && typeof secondArg === 'object') {
+        // 第二个参数是对象，表示额外的数据
+          data = secondArg;
+        } else {
+          data.count = count; // 若没有提供第二个参数，则将 count 添加到数据中
+        }
+      } else if (typeof firstArg === 'object' && firstArg !== null) {
+      // 第一个参数是对象，表示数据
+        data = firstArg;
+      }
+    }
 
     // 处理复数形式：支持 "no items | one item | {count} items" 格式
     if (text.includes('|')) {
       const pluralParts = text.split('|').map((part) => part.trim());
 
-      // 如果数据中包含 count 字段，则使用复数处理
-      if (data && typeof data.count === 'number') {
-        const pluralIndex = getPluralIndex(data.count);
+      if (typeof count === 'number') {
+      // 使用 count 进行复数处理
+        const pluralIndex = getPluralIndex(count);
 
         // 根据复数索引选择对应的文本
         if (pluralIndex < pluralParts.length) {
           text = pluralParts[pluralIndex];
         } else {
-          // 如果索引超出范围，使用最后一个选项
+        // 如果索引超出范围，使用最后一个选项
           text = pluralParts[pluralParts.length - 1];
         }
       } else {
-        // 如果没有 count 字段，默认使用第一个选项
+      // 如果没有 count，默认使用第一个选项
         const [firstPart] = pluralParts;
         text = firstPart;
       }
     }
 
     // 处理变量替换：{key} 格式
-    if (data) {
+    if (data && Object.keys(data).length > 0) {
       const regular = /\{\s*([\w-]+)\s*\}/g;
       text = text.replace(regular, (match, key) => {
-        if (data && Object.prototype.hasOwnProperty.call(data, key)) {
+        if (Object.prototype.hasOwnProperty.call(data, key)) {
           return String(data[key]);
         }
         return match; // 如果找不到对应的键，保留原始占位符
@@ -80,4 +108,4 @@ export const t = function t<T>(pattern: T, ...args: any[]) {
 
   // 如果不是字符串或函数，返回空字符串
   return '';
-};
+}

--- a/test/unit/locale/locale.test.ts
+++ b/test/unit/locale/locale.test.ts
@@ -79,6 +79,7 @@ describe('国际化函数 t', () => {
       expect(t('no items | one item | {count} items', 0)).toBe('no items');
       expect(t('no items | one item | {count} items', 1)).toBe('one item');
       expect(t('no items | one item | {count} items', 5)).toBe('5 items');
+      expect(t('no items | one item | items', 5)).toBe('items');
     });
 
     it('应该正确处理包含其他变量的复数文本', () => {

--- a/test/unit/locale/locale.test.ts
+++ b/test/unit/locale/locale.test.ts
@@ -35,16 +35,16 @@ describe('国际化函数 t', () => {
 
   describe('复数处理', () => {
     it('当 count = 0 时应该使用第一个选项', () => {
-      expect(t('no apples | one apple | {count} apples', { count: 0 })).toBe('no apples');
+      expect(t('no apples | one apple | {count} apples', 0)).toBe('no apples');
     });
 
     it('当 count = 1 时应该使用第二个选项', () => {
-      expect(t('no apples | one apple | {count} apples', { count: 1 })).toBe('one apple');
+      expect(t('no apples | one apple | {count} apples', 1)).toBe('one apple');
     });
 
     it('当 count > 1 时应该使用第三个选项', () => {
-      expect(t('no apples | one apple | {count} apples', { count: 5 })).toBe('5 apples');
-      expect(t('no apples | one apple | {count} apples', { count: 100 })).toBe('100 apples');
+      expect(t('no apples | one apple | {count} apples', 5)).toBe('5 apples');
+      expect(t('no apples | one apple | {count} apples', 100)).toBe('100 apples');
     });
 
     it('当没有 count 字段时应该使用第一个选项', () => {
@@ -53,34 +53,34 @@ describe('国际化函数 t', () => {
     });
 
     it('当复数选项数量不足时应该使用最后一个选项', () => {
-      expect(t('zero | many', { count: 0 })).toBe('zero');
-      expect(t('zero | many', { count: 1 })).toBe('many');
-      expect(t('zero | many', { count: 5 })).toBe('many');
+      expect(t('zero | many', 0)).toBe('zero');
+      expect(t('zero | many', 1)).toBe('many');
+      expect(t('zero | many', 5)).toBe('many');
     });
 
     it('应该正确处理复数选项前后的空格', () => {
-      expect(t(' no items |  one item  | many items ', { count: 0 })).toBe('no items');
-      expect(t(' no items |  one item  | many items ', { count: 1 })).toBe('one item');
-      expect(t(' no items |  one item  | many items ', { count: 5 })).toBe('many items');
+      expect(t(' no items |  one item  | many items ', 0)).toBe('no items');
+      expect(t(' no items |  one item  | many items ', 1)).toBe('one item');
+      expect(t(' no items |  one item  | many items ', 5)).toBe('many items');
     });
   });
 
   describe('复合使用（复数 + 变量替换）', () => {
     it('应该正确处理复数选择和变量替换的组合', () => {
-      expect(t('no items found | found {count} item | found {count} items', { count: 0 }))
+      expect(t('no items found | found {count} item | found {count} items', 0))
         .toBe('no items found');
-      expect(t('no items found | found {count} item | found {count} items', { count: 1 }))
+      expect(t('no items found | found {count} item | found {count} items', 1, { count: 1 }))
         .toBe('found 1 item');
-      expect(t('no items found | found {count} item | found {count} items', { count: 3 }))
+      expect(t('no items found | found {count} item | found {total} items', 3, { total: 3 }))
         .toBe('found 3 items');
     });
 
     it('应该正确处理包含其他变量的复数文本', () => {
-      expect(t('no {type} | one {type} ({count}) | {count} {type}s', { count: 0, type: 'file' }))
+      expect(t('no {type} | one {type} ({count}) | {count} {type}s', 0, { type: 'file' }))
         .toBe('no file');
-      expect(t('no {type} | one {type} ({count}) | {count} {type}s', { count: 1, type: 'file' }))
+      expect(t('no {type} | one {type} ({count}) | {count} {type}s', 1, { count: 1, type: 'file' }))
         .toBe('one file (1)');
-      expect(t('no {type} | one {type} ({count}) | {count} {type}s', { count: 5, type: 'file' }))
+      expect(t('no {type} | one {type} ({count}) | {count} {type}s', 5, { count: 5, type: 'file' }))
         .toBe('5 files');
     });
   });
@@ -129,33 +129,9 @@ describe('国际化函数 t', () => {
   });
 
   describe('实际应用场景', () => {
-    it('消息通知场景', () => {
-      const getNotificationText = (count: number) => t('no messages | {count} message | {count} messages', { count });
-
-      expect(getNotificationText(0)).toBe('no messages');
-      expect(getNotificationText(1)).toBe('1 message');
-      expect(getNotificationText(5)).toBe('5 messages');
-    });
-
-    it('文件上传场景', () => {
-      const getFileSelectionText = (count: number) => t('no files selected | {count} file selected | {count} files selected', { count });
-
-      expect(getFileSelectionText(0)).toBe('no files selected');
-      expect(getFileSelectionText(1)).toBe('1 file selected');
-      expect(getFileSelectionText(10)).toBe('10 files selected');
-    });
-
-    it('购物车场景', () => {
-      const getCartText = (count: number) => t('cart is empty | {count} item in cart | {count} items in cart', { count });
-
-      expect(getCartText(0)).toBe('cart is empty');
-      expect(getCartText(1)).toBe('1 item in cart');
-      expect(getCartText(3)).toBe('3 items in cart');
-    });
-
     it('搜索结果场景', () => {
       const pattern = 'Search "{result}". Found no items. | Search "{result}". Found 1 item. | Search "{result}". Found {count} items.';
-      const getSearchResultText = (count: number, result: string) => t(pattern, { count, result });
+      const getSearchResultText = (count: number, result: string) => t(pattern, count, { count, result });
 
       expect(getSearchResultText(0, 'apple')).toBe('Search "apple". Found no items.');
       expect(getSearchResultText(1, 'apple')).toBe('Search "apple". Found 1 item.');

--- a/test/unit/locale/locale.test.ts
+++ b/test/unit/locale/locale.test.ts
@@ -71,8 +71,14 @@ describe('国际化函数 t', () => {
         .toBe('no items found');
       expect(t('no items found | found {count} item | found {count} items', 1, { count: 1 }))
         .toBe('found 1 item');
-      expect(t('no items found | found {count} item | found {total} items', 3, { total: 3 }))
+      expect(t('no items found | found {count} item | found {count} items', 3, { count: 3 }))
         .toBe('found 3 items');
+    });
+
+    it('应该正确处理只传入 count 的情况', () => {
+      expect(t('no items | one item | {count} items', 0)).toBe('no items');
+      expect(t('no items | one item | {count} items', 1)).toBe('one item');
+      expect(t('no items | one item | {count} items', 5)).toBe('5 items');
     });
 
     it('应该正确处理包含其他变量的复数文本', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

支持 t 传入第二个数字参数以使用复数形式

```ts
t('no apples | one apple | {count} apples', 1) // => 'one apple'

t('no items found | found {count} item | found {count} items', 3, { count: 3 }) // => 'found 3 items'
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(i18n): 支持 t 传入第二个数字参数以使用复数形式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
