### PR TITLE
style: sync design token

### DIFF
--- a/style/mobile/_variables.less
+++ b/style/mobile/_variables.less
@@ -149,7 +149,9 @@
 @bg-color-secondarycomponent-active: var(--td-bg-color-secondarycomponent-active, @gray-color-6);
 
 @component-stroke: var(--td-component-stroke, @gray-color-3);
+@border-level-1-color: var(--td-border-level-1-color, @gray-color-3);
 @component-border: var(--td-component-border, @gray-color-4);
+@border-level-2-color: var(--td-border-level-2-color, @gray-color-4);
 
 // 主题
 @brand-color: var(--td-brand-color, @brand-color-7);
@@ -185,6 +187,9 @@
 @text-color-anti: var(--td-text-color-anti, @font-white-1); // 色彩-文字-反色
 @text-color-brand: var(--td-text-color-brand, @brand-color); // 色彩-文字-品牌
 @text-color-link: var(--td-text-color-link, @brand-color); // 色彩-文字-链接
+
+// 定位
+@position-fixed-top: var(--td-position-fixed-top, 0);
 
 // 遮罩
 @mask-active: rgba(0, 0, 0, .6); // 遮罩-弹出

--- a/style/mobile/theme/_dark.less
+++ b/style/mobile/theme/_dark.less
@@ -120,7 +120,7 @@
   --td-text-color-secondary: var(--td-font-white-2); // 色彩-文字-次要
   --td-text-color-placeholder: var(--td-font-white-3); // 色彩-文字-占位符/说明
   --td-text-color-disabled: var(--td-font-white-4); // 色彩-文字-禁用
-  --td-text-color-anti: var(--td-font-gray-1); // 色彩-文字-反色
+  --td-text-color-anti: var(--td-font-white-1); // 色彩-文字-反色
   --td-text-color-brand: var(--td-brand-color-8); // 色彩-文字-品牌
   --td-text-color-link: var(--td-brand-color-8); // 色彩-文字-链接
 


### PR DESCRIPTION
- 同步 design token


### 相关 PRs
https://github.com/Tencent/tdesign/pull/685


### 背景
小程序官网深色模式部分组件色值错误
如：https://tdesign.tencent.com/miniprogram/components/switch

<img width="453" alt="截屏2025-07-01 19 35 58" src="https://github.com/user-attachments/assets/102d4e7e-6ccd-4912-bddd-a81440e5aac3" />

### 方案

使用正确的 design token

### 视觉稿

<img width="1182" alt="截屏2025-07-01 19 37 15" src="https://github.com/user-attachments/assets/7d7a4949-bd45-4e73-9aae-ca79bc6406c5" />


<img width="1210" alt="截屏2025-07-01 19 37 03" src="https://github.com/user-attachments/assets/c87943ff-4428-4559-86a4-2bbfe11b2194" />
