### PR TITLE
fix(message): avoid transparent area of message list blocking pointer events

### DIFF
--- a/style/web/components/message/_index.less
+++ b/style/web/components/message/_index.less
@@ -70,9 +70,11 @@
 .@{prefix}-message__list {
   position: fixed;
   z-index: 6000;
+  pointer-events: none;
 
   .@{prefix}-message {
     margin-bottom: @msg-list-margin-bottom;
     word-break: break-all;
+    pointer-events: auto;
   }
 }


### PR DESCRIPTION
Fixes an issue where the .t-message__list container's expanded width could create transparent areas outside of short messages.  
These areas visually expose underlying elements but block pointer events, making them unclickable.  
This change disables pointer events on the container and re-enables them on each message item.

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!-- 如无关联 Issue，可留空 -->

### 💡 需求背景和解决方案

**问题背景：**

当页面中存在多条 `Message` 时，`.t-message__list` 容器宽度可能被某条长消息撑开，造成右侧出现透明但实际阻断事件的区域。  
如果该区域下方存在按钮等元素，即使视觉上可以看到，也无法被点击，影响用户体验。

**解决方案：**

- 为 `.t-message__list` 设置 `pointer-events: none`，使容器透明区域不阻挡鼠标事件；
- 为每条 `.t-message` 恢复 `pointer-events: auto`，确保消息内容可正常交互。

**改动前效果（不能触发‘测试按钮‘点击事件）：**

![img_v3_02nr_c455874f-091a-4854-9abf-2e0446b5d36g](https://github.com/user-attachments/assets/048c6985-2e44-4de8-8d52-b9f03d148a3a)

**改动后效果：**

![img_v3_02nr_043aca92-c813-4957-b685-7080c340620g](https://github.com/user-attachments/assets/a9960288-644b-4b2c-b779-6de741061649)


### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
- fix(message): avoid transparent area of message list blocking pointer events

#### @tdesign-vue-next/chat
<!-- 若无 chat 子包改动可删去 -->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
