### PR TITLE
fix(dialog): restrict header icon style to direct children

### DIFF
--- a/style/web/components/dialog/_index.less
+++ b/style/web/components/dialog/_index.less
@@ -57,14 +57,14 @@
       display: flex;
       align-items: flex-start;
       width: 100%;
-    }
 
-    .t-icon:not(.t-icon-close) {
-      font-size: @dialog-icon-size;
-      display: inline-flex;
-      align-items: center;
-      margin-right: @dialog-header-icon-margin-right;
-      flex-shrink: 0;
+      >.t-icon {
+        font-size: @dialog-icon-size;
+        display: inline-flex;
+        align-items: center;
+        margin-right: @dialog-header-icon-margin-right;
+        flex-shrink: 0;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

N/A（样式问题，未记录 Issue，可视为内部样式修复）

---

### 💡 需求背景和解决方案

当前 `<t-dialog>` 的 `.t-dialog__header` 中，样式选择器：

```less
.t-dialog__header .t-icon:not(.t-icon-close)
```

作用范围过大，会影响 `header` 插槽中用户自定义组件（如 `<t-breadcrumb>`、`<t-button>`）内的 `.t-icon`，造成图标尺寸和样式异常。

#### ✅ 修改方案

将选择器修改为仅匹配 **直系子元素**：

```less
.t-dialog__header-content > .t-icon
```

#### 🎯 修改效果

- ✅ 保留 header 前缀 icon 的样式不变；
- ✅ 避免误伤插槽嵌套结构中组件的图标；
- ⚠️ **属于轻微破坏性更改**：如果用户依赖 `.t-dialog__header` 中深层 `.t-icon` 被放大的副作用（少见），此改动会使其恢复正常。

---

### 效果截图对比（前 / 后）

#### ❌ 修改前（嵌套组件 icon 被误伤）
![image](https://github.com/user-attachments/assets/87cdd403-76bd-40ca-8de9-9535536b168a)

#### ✅ 修改后（嵌套组件样式恢复正常）

![image](https://github.com/user-attachments/assets/fa7ece02-a91e-443d-98cb-be011f988a60)

#### ✅ header 中直系 icon 样式仍保留（视觉不变）
![image](https://github.com/user-attachments/assets/d2e19ab5-97f8-4b7d-bd9c-8add5d534050)
#### ⚠️ 会对文档中的 "自定义 icon"  demo 产生影响
![image](https://github.com/user-attachments/assets/bbcdb065-41ce-46a3-b2f2-070ccad3efec)
---

### 📝 更新日志

- fix(dialog): 限制 header icon 样式为直系子元素，避免误伤插槽嵌套组件的图标

- [ ] 本条 PR 不需要纳入 Changelog

---

### ☑️ 请求合并前的自查清单

⚠️ 请自检并**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
