### PR TITLE
fix(Divider): update api doc

### DIFF
--- a/docs/mobile/api/divider.md
+++ b/docs/mobile/api/divider.md
@@ -1,14 +1,14 @@
 ---
-title: Divider 分割符
+title: Divider 分割线
 description: 用于分割、组织、细化有一定逻辑的组织元素内容和页面结构。
 spline: base
 isComponent: true
 toc: false
 ---
 
-### 基础分割符
+### 基础分割线
 
-分割符主要是由直线和文字组成，通过`slot`传入分割线文案或者其他自定义内容，通过`layout`控制分隔符是垂直还是横向
+分割线主要是由直线和文字组成，通过`slot`传入分割线文案或者其他自定义内容，通过`layout`控制分隔符是垂直还是横向
 
 {{ base }}
 

--- a/docs/mobile/api_v2/divider.md
+++ b/docs/mobile/api_v2/divider.md
@@ -1,14 +1,14 @@
 ---
-title: Divider 分割符
+title: Divider 分割线
 description: 用于分割、组织、细化有一定逻辑的组织元素内容和页面结构。
 spline: base
 isComponent: true
 toc: false
 ---
 
-### 基础分割符
+### 基础分割线
 
-分割符主要是由直线和文字组成，通过`slot`传入分割线文案或者其他自定义内容，通过`layout`控制分隔符是垂直还是横向
+分割线主要是由直线和文字组成，通过`slot`传入分割线文案或者其他自定义内容，通过`layout`控制分隔符是垂直还是横向
 
 {{ base }}
 


### PR DESCRIPTION
- Divider 中文名称从 “分割符” 变更为 “分割线”

<img width="626" height="328" alt="截屏2025-07-15 20 37 46" src="https://github.com/user-attachments/assets/d8f24f21-c4be-45c0-8ca0-ec4059cb0b84" />
