### PR TITLE
fix(ColorPicker): handle hue reset when saturation is zero in HSV model

### DIFF
--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -2,7 +2,10 @@ import tinyColor from 'tinycolor2';
 import { cmykInputToColor, rgb2cmyk } from './cmyk';
 import { ALPHA_FORMAT_MAP } from './constants';
 import {
-  parseGradientString, GradientColors, GradientColorPoint, isGradientColor
+  GradientColorPoint,
+  GradientColors,
+  isGradientColor,
+  parseGradientString
 } from './gradient';
 import type { AlphaConvertibleFormat, ColorFormat } from './types';
 
@@ -44,8 +47,6 @@ const hsv2hsla = (states: ColorStates): tinyColor.ColorFormats.HSLA => tinyColor
 
 /**
  * 将渐变对象转换成字符串
- * @param object
- * @returns
  */
 export const gradientColors2string = (object: GradientColors): string => {
   const { points, degree } = object;
@@ -58,8 +59,6 @@ export const gradientColors2string = (object: GradientColors): string => {
 
 /**
  * 去除颜色的透明度
- * @param color
- * @returns
  */
 export const getColorWithoutAlpha = (color: string) => tinyColor(color).setAlpha(1).toHexString();
 
@@ -106,12 +105,7 @@ export class Color {
     const gradientColors = parseGradientString(input);
 
     if (this.isGradient && !gradientColors) {
-      /* 这里是针对渐变模式下，修改某个位置点的色值情况
-
-       「Tip」
-        - 为了避免有时外界从渐变切换到单色模式，存在缓存问题
-          需要手动设置 `color.isGradient = false` 进行同步
-        - 特定场景下，也可以直接创建新实例 `new Color` 进行覆盖 */
+      /* case 1: 渐变模式单独修改某个位置点的色值 */
       const colorHsv = tinyColor(input).toHsv();
       this.states = colorHsv;
       this.updateCurrentGradientColor();
@@ -120,6 +114,8 @@ export class Color {
     this.originColor = input;
     this.isGradient = false;
     let colorInput = input;
+
+    /* case 2: 修改整个渐变，生成一套新的颜色点 */
     if (gradientColors) {
       this.isGradient = true;
       const object = gradientColors as GradientColors;
@@ -319,12 +315,20 @@ export class Color {
     const color = tinyColor(cmykInputToColor(input));
     const hsva = color.toHsv();
 
-    /* 在 HSV 颜色模型中，当饱和度 (saturation) 为 0 时
-       颜色处于纯白/黑区域，此时色相 (hue) 在数学上是未定义的，tinyColor 库会将其重置为 0
-       因此当用户拖动到该区域时，会导致 Slider 上的点位置计算意外错误 */
-    if (hsva.h !== this.states.h) {
-      // 始终与当前色相同步，避免 hsva.s === 0 时 hue 被重置
+    /* case 1: 当颜色在黑/灰/白区域，转换后的色相 (H) 与饱和度（S）不稳定
+       为了避免跳变，强制保持原有的值 */
+    const isTooGray = hsva.s * hsva.v <= 0.04;
+    const isTooDark = hsva.v <= 0.02;
+
+    /* case 2: Hue 是 0–360° 的环形值，0° 和 360° 表示相同的颜色
+       当用户在 Slider 最右端（接近 360°）来回拖拽时，也容易出现跳变 */
+    const diff = Math.abs(hsva.h - this.states.h);
+    if (isTooGray || diff > 355) {
       hsva.h = this.states.h;
+    }
+
+    if (isTooDark) {
+      hsva.s = this.states.s;
     }
 
     this.states = hsva;
@@ -387,8 +391,6 @@ export class Color {
 
   /**
    * 判断输入色是否与当前色相同
-   * @param color
-   * @returns
    */
   equals(color: string): boolean {
     return tinyColor.equals(this.rgba, color);
@@ -406,47 +408,28 @@ export class Color {
     return tinyColor(color).isValid();
   }
 
-  static hsva2color(h: number, s: number, v: number, a: number) {
-    return tinyColor({
-      h, s, v, a
-    }).toHsvString();
-  }
-
-  static hsla2color(h: number, s: number, l: number, a: number) {
-    return tinyColor({
-      h, s, l, a
-    }).toHslString();
-  }
-
-  static rgba2color(r: number, g: number, b: number, a: number) {
-    return tinyColor({
-      r, g, b, a
-    }).toHsvString();
-  }
-
-  static hex2color(hex: string, a: number) {
-    const color = tinyColor(hex);
-    color.setAlpha(a);
-    return color.toHexString();
-  }
-
   /**
    * 对象转颜色字符串
-   * @param object
-   * @param format
-   * @returns
    */
-  static object2color(object: any, format: string) {
+  static object2color(object: any, format: ColorFormat) {
     if (format === 'CMYK') {
-      const {
-        c, m, y, k
-      } = object;
+      const { c, m, y, k } = object;
       return `cmyk(${c}, ${m}, ${y}, ${k})`;
     }
-    const color = tinyColor(object, {
-      format,
-    });
-    return color.toRgbString();
+
+    if (format === 'RGB' || format === 'RGBA') {
+      return tinyColor(object).toRgbString();
+    }
+
+    if (format === 'HSL' || format === 'HSLA') {
+      return tinyColor(object).toHslString();
+    }
+
+    if (format === 'HSV' || format === 'HSVA') {
+      return tinyColor(object).toHsvString();
+    }
+
+    return tinyColor(object).toHexString();
   }
 
   /**

--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -320,9 +320,10 @@ export class Color {
     const hsva = color.toHsv();
 
     /* 在 HSV 颜色模型中，当饱和度 (saturation) 为 0 时
-       颜色处于白色区域，此时色相 (hue) 在数学上是未定义的，tinyColor 库会将其重置为 0
-       从而导致 Slider 上的点位置计算意外错误 */
-    if (hsva.s === 0 && this.states.h > 0) {
+       颜色处于纯白/黑区域，此时色相 (hue) 在数学上是未定义的，tinyColor 库会将其重置为 0
+       因此当用户拖动到该区域时，会导致 Slider 上的点位置计算意外错误 */
+    if (hsva.h !== this.states.h) {
+      // 始终与当前色相同步，避免 hsva.s === 0 时 hue 被重置
       hsva.h = this.states.h;
     }
 

--- a/js/color-picker/color.ts
+++ b/js/color-picker/color.ts
@@ -318,6 +318,14 @@ export class Color {
   updateStates(input: string) {
     const color = tinyColor(cmykInputToColor(input));
     const hsva = color.toHsv();
+
+    /* 在 HSV 颜色模型中，当饱和度 (saturation) 为 0 时
+       颜色处于白色区域，此时色相 (hue) 在数学上是未定义的，tinyColor 库会将其重置为 0
+       从而导致 Slider 上的点位置计算意外错误 */
+    if (hsva.s === 0 && this.states.h > 0) {
+      hsva.h = this.states.h;
+    }
+
     this.states = hsva;
   }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-react/issues/3675
https://github.com/Tencent/tdesign-react/issues/3685

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ColorPicker): 减小在色彩空间中色相 (H) 和饱和度 (S) 的转换偏差

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
