### PR TITLE
fix(tag-input): `suffixIcon` position error

### DIFF
--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -104,7 +104,7 @@
 // 标签数量超出时，换行显示
 .@{prefix}-tag-input--break-line:not(.@{prefix}-is-empty) {
 
-  .@{prefix}-input {
+  .@{prefix}-input__prefix {
     display: block;
 
     &.@{prefix}-input--prefix > .@{prefix}-input__prefix {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

这里之前是 display flex 正常的，但是在 tag input 的时候有这个判断，因为 `excessTagsDisplayType` api 判断就把整个 t-input 都变成 block 了。


<img width="688" height="253" alt="40375092143" src="https://github.com/user-attachments/assets/585ba346-6ca0-427c-89f0-e6a6e0997cab" />

<img width="1874" height="754" alt="540389672944" src="https://github.com/user-attachments/assets/cb7dd28b-627c-4f0a-8421-205388b67aec" />


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tag-input): 后置图标位置错误问题
- fix(select): 在多选情况下后置图标位置错误问题
- fix(select-input): 在多选情况下后置图标位置错误问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
