### PR TITLE
fix(Avatar): change group offset value to -4px

### DIFF
--- a/style/mobile/components/avatar/_var.less
+++ b/style/mobile/components/avatar/_var.less
@@ -22,9 +22,9 @@
 @avatar-margin-left: var(--td-avatar-margin-left, 0);
 
 //组合头像偏移量
-@avatar-group-offset-small: var(--td-avatar-group-margin-left-small, -8px);
-@avatar-group-offset-medium: var(--td-avatar-group-margin-left-medium, -8px);
-@avatar-group-offset-large: var(--td-avatar-group-margin-left-large, -8px);
+@avatar-group-offset-small: var(--td-avatar-group-margin-left-small, -4px);
+@avatar-group-offset-medium: var(--td-avatar-group-margin-left-medium, -4px);
+@avatar-group-offset-large: var(--td-avatar-group-margin-left-large, -4px);
 @avatar-group-line-spacing: var(--td-avatar-group-line-spacing, 2px);
 
 @avatar-group-init-zIndex: 50;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-mobile-react/issues/697

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
我在进行 Avatar 组件的功能自查，发现 [Figma 设计稿](https://www.figma.com/design/jivYXTMTP3jEkeZXWbMh4J/branch/4SdclZkcv5bPgX6pa8AsmI/TDesign-for-mobile?node-id=24386-5260&p=f&m=dev)中提到了 `<AvatarGroup />` 中按钮间距应为 `-4px`，因此把 less 变量默认值进行了调整

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Avatar): AvatarGroup 按钮间距默认值从 -8px 调整为 -4px

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
