### PR TITLE
fix(Textarea): use the correct CSS token

### DIFF
--- a/style/mobile/components/textarea/_index.less
+++ b/style/mobile/components/textarea/_index.less
@@ -77,7 +77,19 @@
 
   &--border {
     border-radius: @textarea-border-radius;
-    border: @textarea-border-width solid @textarea-border-color;
+    position: relative;
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      border: @textarea-border-width solid @textarea-border-color;
+      border-radius: inherit;
+      pointer-events: none;
+    }
   }
 
   &--disabled {

--- a/style/mobile/components/textarea/_var.less
+++ b/style/mobile/components/textarea/_var.less
@@ -25,6 +25,6 @@
 // 文本框圆角大小
 @textarea-border-radius: var(--td-textarea-border-radius, @radius-default);
 // 文本框边框颜色
-@textarea-border-color: var(--td-textarea-border-color, rgba(220, 220, 220, 1));
+@textarea-border-color: var(--td-textarea-border-color, @component-border);
 // 文本框禁用状态时的输入文本颜色
 @textarea-disabled-text-color: var(--td-textarea-disabled-text-color, @text-color-disabled);


### PR DESCRIPTION
### Textarea
- 修复 `border-color` 颜色错误
- 改用伪元素实现边框，避免占位