### PR TITLE
fix(tabs): offset distance being too small

### DIFF
--- a/js/tabs/base.ts
+++ b/js/tabs/base.ts
@@ -53,10 +53,16 @@ export function calcPrevOrNextOffset(elements: allElementDeps, offset: number, a
    * 所以需要取绝对值
    */
   const diffWidth = Math.abs(navsContainerWidth - activeTabWidth);
+  /**
+   * 偏移量的最小值设为容器 navsContainer 的宽度的一半
+   * 以避免 activeTab 和 navsContainer 宽度接近时偏移量过小，导致很难滚动，甚至无法滚动
+   */
+  const distance = Math.max(diffWidth, navsContainerWidth / 2);
+
   if (action === 'next') {
-    return offset + diffWidth;
+    return offset + distance;
   }
-  return offset - diffWidth;
+  return offset - distance;
 }
 
 /**


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

### 💡 需求背景和解决方案

背景：当前 tabs 前进/后退的滚动距离，是基于“激活 tab 宽度”和“tab 容器宽度”的差值，当二者数值接近时，会导致很难滚动甚至无法滚动。

问题视频：https://gpts-prod-1312254802.cos.ap-singapore.myqcloud.com/creatorhub/temp/tabs-bug.mov

解决方案：tabs 前进/后退的滚动距离设为至少为容器宽度的一半。

### 📝 更新日志

- fix(tabs): 修复部分场景下滚动距离过小的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
