### PR TITLE
fix: 修复 tooltip + textarea 组合时抛出异常的问题 (#6028)

### DIFF
--- a/js/utils/calcTextareaHeight.ts
+++ b/js/utils/calcTextareaHeight.ts
@@ -27,6 +27,11 @@ function calcTextareaHeight(
   minRows: LimitType = 1,
   maxRows: LimitType = null,
 ): CalculateStyleType {
+  // 验证元素有效性 - 修复 Bug #6028
+  if (!targetElement || !targetElement.isConnected) {
+    return { height: 'auto' };
+  }
+
   if (!hiddenTextarea) {
     hiddenTextarea = document.createElement('textarea');
     document.body.appendChild(hiddenTextarea);

--- a/js/utils/helper.ts
+++ b/js/utils/helper.ts
@@ -241,7 +241,21 @@ export function calculateNodeSize(targetElement: HTMLElement) {
     };
   }
 
-  const style = window.getComputedStyle(targetElement);
+  // 验证元素有效性 - 修复 Bug #6028
+  if (!targetElement
+      || !(targetElement instanceof Element)
+      || !targetElement.isConnected
+      || !document.contains(targetElement)) {
+    return {
+      paddingSize: 0,
+      borderSize: 0,
+      boxSizing: 'border-box',
+      sizingStyle: '',
+    };
+  }
+
+  try {
+    const style = window.getComputedStyle(targetElement);
 
   const boxSizing = style.getPropertyValue('box-sizing')
     || style.getPropertyValue('-moz-box-sizing')
@@ -261,7 +275,15 @@ export function calculateNodeSize(targetElement: HTMLElement) {
     .map((name) => `${name}:${style.getPropertyValue(name)}`)
     .join(';');
 
-  return {
-    paddingSize, borderSize, boxSizing, sizingStyle,
-  };
+    return {
+      paddingSize, borderSize, boxSizing, sizingStyle,
+    };
+  } catch (error) {
+    return {
+      paddingSize: 0,
+      borderSize: 0,
+      boxSizing: 'border-box',
+      sizingStyle: '',
+    };
+  }
 }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/6028

### 💡 需求背景和解决方案

- 在 calculateNodeSize 函数中添加元素有效性检查
- 在 calcTextareaHeight 函数中添加元素连接性验证
- 增加 try-catch 异常处理和优雅降级
- 修复 getComputedStyle 参数无效导致的异常

修复详情:
1. 验证 targetElement 是否为有效的 DOM 元素
2. 检查元素是否已连接到 DOM 树
3. 添加异常处理确保函数不会崩溃
4. 提供合理的默认返回值

这个修复解决了在某些边缘情况下，当 DOM 元素状态不稳定时
getComputedStyle 抛出 'parameter 1 is not of type Element' 异常的问题。