### PR TITLE
fix(image-viewer): optimize the image download logic

### DIFF
--- a/js/image-viewer/types.d.ts
+++ b/js/image-viewer/types.d.ts
@@ -1,0 +1,8 @@
+export interface ImageInfo {
+  mainImage: string | File;
+  thumbnail?: string | File;
+  download?: boolean;
+  isSvg?: boolean;
+}
+
+export type Images = Array<string | File | ImageInfo>;

--- a/js/image-viewer/utils.ts
+++ b/js/image-viewer/utils.ts
@@ -1,0 +1,95 @@
+import { isArray, isString } from 'lodash-es';
+import type { ImageInfo, Images } from './types';
+
+const isSameOrigin = (url: string) => {
+  try {
+    const imgUrl = new URL(url, window.location.href);
+    return imgUrl.origin === window.location.origin;
+  } catch {
+    return true;
+  }
+};
+
+const directDownload = (imgSrc: string, name: string) => {
+  const a = document.createElement('a');
+  a.download = name;
+  a.href = imgSrc;
+  a.click();
+  a.remove();
+};
+
+const canvasDownload = (imgSrc: string, name: string) => {
+  const image = new Image();
+  image.setAttribute('crossOrigin', 'anonymous');
+
+  image.onload = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = image.width;
+    canvas.height = image.height;
+
+    const context = canvas.getContext('2d');
+    context.drawImage(image, 0, 0, image.width, image.height);
+    canvas.toBlob((blob) => {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.download = name;
+      a.href = url;
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    });
+  };
+
+  image.src = imgSrc;
+};
+
+const fileDownload = (file: File, name: string) => {
+  const url = URL.createObjectURL(file);
+  const a = document.createElement('a');
+  a.download = name;
+  a.href = url;
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
+
+export const downloadFile = (imgSrc: string | File) => {
+  const randomName = Math.random().toString(32).slice(2);
+
+  if (imgSrc instanceof File) {
+    fileDownload(imgSrc, imgSrc.name);
+    return;
+  }
+
+  // fix: https://github.com/Tencent/tdesign-vue-next/issues/2936
+  // 当链接携带了参数时，需处理掉参数再取图片名称，否则扩展名会与参数链接导致原扩展名失效
+  // 例如：img.png?sign=xxx 不处理参数会被转成 img.png_sign=xxx
+  const name = imgSrc?.split?.('?')?.[0]?.split?.('#')?.[0]?.split?.('/').pop()
+    || randomName;
+
+  if (isSameOrigin(imgSrc)) {
+    directDownload(imgSrc, name);
+  } else {
+    canvasDownload(imgSrc, name);
+  }
+};
+
+const isImageInfo = (image: string | File | ImageInfo): image is ImageInfo => !!image && !isString(image) && !(image instanceof File);
+
+export const formatImages = (images: Images): ImageInfo[] => {
+  if (!isArray(images)) return [];
+  return images.map((item) => {
+    if (isImageInfo(item)) {
+      return {
+        download: true,
+        thumbnail: item.mainImage,
+        ...item,
+      };
+    }
+    return {
+      mainImage: item,
+      thumbnail: item,
+      download: true,
+    };
+  });
+};


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-vue-next/issues/5979

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- 迁移可复用逻辑到公共仓
- 优化下载图片的逻辑，如果不是跨域地址，不需要再转 canvas 进行绘制，也避免了某些 `.gif` 动图失效的问题，降低用户自行封装 `onDownload` 逻辑的成本

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ImageViewer): 避免同域图片进行二次转换导致下载文件过大或动图失效等问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
