### PR TITLE
feat(Loading): enhance loading text styles for different sizes and ad…

### DIFF
--- a/style/web/components/loading/_index.less
+++ b/style/web/components/loading/_index.less
@@ -87,9 +87,24 @@
 .@{prefix}-loading__text {
   width: auto;
   display: inline-block;
-  vertical-align: middle;
+  vertical-align: unset;
   font: @loading-text-size;
-  margin-left: @loading-text-margin-left;
+  margin-left: @loading-text-margin-left-m;
+}
+
+.@{prefix}-size-s .@{prefix}-loading__text {
+  font: @loading-text-size-s;
+  margin-left: @loading-text-margin-left-s;
+}
+
+.@{prefix}-size-m .@{prefix}-loading__text {
+  font: @loading-text-size-m;
+  margin-left: @loading-text-margin-left-m;
+}
+
+.@{prefix}-size-l .@{prefix}-loading__text {
+  font: @loading-text-size-l;
+  margin-left: @loading-text-margin-left-l;
 }
 
 .@{prefix}-loading__gradient {

--- a/style/web/components/loading/_var.less
+++ b/style/web/components/loading/_var.less
@@ -18,13 +18,18 @@
 
 // 字号
 @loading-text-size: @font-body-medium;
+@loading-text-size-s: @font-body-small;
+@loading-text-size-m: @font-body-medium;
+@loading-text-size-l: @font-body-large;
 @loading-icon-size: @comp-size-l;
 @loading-icon-size-small: @comp-size-xxxs;
 @loading-icon-size-large: @comp-size-xxxl;
 @loading-fullscreen-icon-size: @loading-icon-size;
 
 // 间距
-@loading-text-margin-left: @comp-margin-xs;
+@loading-text-margin-left-s: @comp-margin-xs;
+@loading-text-margin-left-m: @comp-margin-s;
+@loading-text-margin-left-l: @comp-margin-m;
 @loading-gradient-padding-s: 1px;
 @loading-gradient-padding-m: 3px;
 @loading-gradient-padding-l: 5px;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 💡 需求背景和解决方案

<img width="1049" height="398" alt="a75803f242480a78f9e155e641f544d7" src="https://github.com/user-attachments/assets/8d65a9d2-ea07-4f66-8646-e48620a2f79b" />

1. loading组件中的图标与文字并未水平对齐。通过为 `t-loading__text` 设置 `vertical-align: unset` 解决          
2. 在不同的 `size` 下加载图标与提示文字的间距过于小。通过为 `margin-left` 设置合适的外边距变量解决           
3. 在不同的 `size` 下提示文字的大小不太合适。通过为 `font` 设置合适的字体大小变量解决       

### 📝 更新日志

- fix(Loading): 优化Loading组件在不同 `size` 下的样式


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供


第一次为开源项目提交pr，如有不足，还请指出