### PR TITLE
fix(image-viewer): correct origin check and enhance canvas download quality

### DIFF
--- a/js/image-viewer/utils.ts
+++ b/js/image-viewer/utils.ts
@@ -1,12 +1,14 @@
 import { isArray, isString } from 'lodash-es';
 import type { ImageInfo, Images } from './types';
 
+const COMPRESSED_FORMATS = ['jpg', 'jpeg', 'webp'];
+
 const isSameOrigin = (url: string) => {
   try {
     const imgUrl = new URL(url, window.location.href);
     return imgUrl.origin === window.location.origin;
   } catch {
-    return true;
+    return false;
   }
 };
 
@@ -29,17 +31,27 @@ const canvasDownload = (imgSrc: string, name: string) => {
 
     const context = canvas.getContext('2d');
     context.drawImage(image, 0, 0, image.width, image.height);
-    canvas.toBlob((blob) => {
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.download = name;
-      a.href = url;
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-    });
-  };
 
+    const extension = name.split('.').pop()?.toLowerCase() || 'png';
+    const mimeType = `image/${extension === 'jpg' ? 'jpeg' : extension}`;
+
+    let quality = 1.0;
+    if (COMPRESSED_FORMATS.includes(extension)) quality = 0.95;
+
+    canvas.toBlob(
+      (blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.download = name;
+        a.href = url;
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      },
+      mimeType,
+      quality
+    );
+  };
   image.src = imgSrc;
 };
 
@@ -53,7 +65,7 @@ const fileDownload = (file: File, name: string) => {
   URL.revokeObjectURL(url);
 };
 
-export const downloadFile = (imgSrc: string | File) => {
+export const downloadImage = (imgSrc: string | File) => {
   const randomName = Math.random().toString(32).slice(2);
 
   if (imgSrc instanceof File) {

--- a/js/image-viewer/utils.ts
+++ b/js/image-viewer/utils.ts
@@ -20,6 +20,16 @@ const directDownload = (imgSrc: string, name: string) => {
   a.remove();
 };
 
+const fileDownload = (obj: Blob | MediaSource, name: string) => {
+  const url = URL.createObjectURL(obj);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
+
 const canvasDownload = (imgSrc: string, name: string) => {
   const image = new Image();
   image.setAttribute('crossOrigin', 'anonymous');
@@ -40,29 +50,13 @@ const canvasDownload = (imgSrc: string, name: string) => {
 
     canvas.toBlob(
       (blob) => {
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.download = name;
-        a.href = url;
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(url);
+        fileDownload(blob, name);
       },
       mimeType,
       quality
     );
   };
   image.src = imgSrc;
-};
-
-const fileDownload = (file: File, name: string) => {
-  const url = URL.createObjectURL(file);
-  const a = document.createElement('a');
-  a.download = name;
-  a.href = url;
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
 };
 
 export const downloadImage = (imgSrc: string | File) => {

--- a/js/image-viewer/utils.ts
+++ b/js/image-viewer/utils.ts
@@ -1,8 +1,6 @@
 import { isArray, isString } from 'lodash-es';
 import type { ImageInfo, Images } from './types';
 
-const COMPRESSED_FORMATS = ['jpg', 'jpeg', 'webp'];
-
 const isSameOrigin = (url: string) => {
   try {
     const imgUrl = new URL(url, window.location.href);
@@ -45,16 +43,9 @@ const canvasDownload = (imgSrc: string, name: string) => {
     const extension = name.split('.').pop()?.toLowerCase() || 'png';
     const mimeType = `image/${extension === 'jpg' ? 'jpeg' : extension}`;
 
-    let quality = 1.0;
-    if (COMPRESSED_FORMATS.includes(extension)) quality = 0.95;
-
-    canvas.toBlob(
-      (blob) => {
-        fileDownload(blob, name);
-      },
-      mimeType,
-      quality
-    );
+    canvas.toBlob((blob) => {
+      fileDownload(blob, name);
+    }, mimeType);
   };
   image.src = imgSrc;
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-vue-next/issues/5979
- https://github.com/Tencent/tdesign-common/pull/2309

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(ImageViewer): 优化下载跨域图片时的格式处理和压缩比例 
- feat(ImageViewer): 支持直接下载同域图片，避免二次转换导致体积增大和动图失效等问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
