### PR TITLE
refactor(date-picker): 将 `format` 与 `valueType` 分离

### DIFF
--- a/js/date-picker/format.ts
+++ b/js/date-picker/format.ts
@@ -16,39 +16,38 @@ export const TIME_FORMAT = 'HH:mm:ss';
 
 // extract time format from a completed date format 'YYYY-MM-DD HH:mm' -> 'HH:mm'
 export function extractTimeFormat(dateFormat: string = '') {
-  return dateFormat
-    .replace(/\W?Y{2,4}|\W?D{1,2}|\W?Do|\W?d{1,4}|\W?M{1,4}|\W?y{2,4}/g, '')
-    .trim();
+  return dateFormat.replace(/\W?Y{2,4}|\W?D{1,2}|\W?Do|\W?d{1,4}|\W?M{1,4}|\W?y{2,4}/g, '').trim();
 }
 
 // 统一解析日期格式字符串成 Dayjs 对象
-export function parseToDayjs(
-  value: string | Date | number,
-  format: string,
-  timeOfDay?: string,
-  dayjsLocale?: string,
-) {
+export function parseToDayjs(value: string | Date | number, format: string, timeOfDay?: string, dayjsLocale?: string) {
   if (value === '' || value === null) return dayjs();
 
   let dateText = value;
   // format week
   if (/[w|W]/g.test(format)) {
     if (!isString(dateText)) {
-      dateText = dayjs(dateText).locale(dayjsLocale || 'zh-cn').format(format) as string;
+      dateText = dayjs(dateText)
+        .locale(dayjsLocale || 'zh-cn')
+        .format(format) as string;
     }
 
     const yearStr = dateText.split(/[-/.\s]/)[0];
     const weekStr = dateText.split(/[-/.\s]/)[1];
     const weekFormatStr = format.split(/[-/.\s]/)[1];
 
-    let firstWeek = dayjs(yearStr, 'YYYY').locale(dayjsLocale || 'zh-cn').startOf('year');
+    let firstWeek = dayjs(yearStr, 'YYYY')
+      .locale(dayjsLocale || 'zh-cn')
+      .startOf('year');
     // 第一周ISO定义: 本年度第一个星期四所在的星期
     // 如果第一年第一天在星期四后, 直接跳到下一周, 下一周必定是第一周
     // 否则本周即为第一周
     if (firstWeek.day() > 4 || firstWeek.day() === 0) firstWeek = firstWeek.add(1, 'week');
 
     // 一年有52或者53周, 引入IsoWeeksInYear辅助查询
-    const weekCounts = dayjs(yearStr, 'YYYY').locale(dayjsLocale || 'zh-cn').isoWeeksInYear();
+    const weekCounts = dayjs(yearStr, 'YYYY')
+      .locale(dayjsLocale || 'zh-cn')
+      .isoWeeksInYear();
     for (let i = 0; i <= weekCounts; i += 1) {
       let nextWeek = firstWeek.add(i, 'week');
       // 重置为周的第一天
@@ -62,7 +61,9 @@ export function parseToDayjs(
   // format quarter
   if (/Q/g.test(format)) {
     if (!isString(dateText)) {
-      dateText = dayjs(dateText).locale(dayjsLocale || 'zh-cn').format(format) as string;
+      dateText = dayjs(dateText)
+        .locale(dayjsLocale || 'zh-cn')
+        .format(format) as string;
     }
 
     const yearStr = dateText.split(/[-/.\s]/)[0];
@@ -78,36 +79,82 @@ export function parseToDayjs(
   }
 
   // 兼容数据格式不标准场景 YYYY-MM-D
-  const result = dayjs(dateText, format).isValid()
-    ? dayjs(dateText, format)
-    : dayjs(dateText);
+  const result = dayjs(dateText, format).isValid() ? dayjs(dateText, format) : dayjs(dateText);
 
   // 兼容数据异常情况
   if (!result.isValid()) {
-    log.error('DatePicker', `Check whether the format、value format is valid.\n value: '${value}', format: '${format}'`);
+    log.error(
+      'DatePicker',
+      `Check whether the format、value format is valid.\n value: '${value}', format: '${format}'`
+    );
     return dayjs();
   }
 
   return result;
 }
 
-// 格式化 range
-function formatRange({
+/**
+ * @description: 格式化单个日期值 - 通用处理
+ * @param {Object} params - 参数对象
+ * @param {string | number | Date} params.newDate - 输入的日期值
+ * @param {string} params.format - 默认日期格式
+ * @param {string} [params.dayjsLocale="zh-cn"] - dayjs 语言环境
+ * @param {Function} formatter - 格式化函数，接受 dayjs 对象和格式，返回格式化结果
+ * @returns {string | number | Date} 格式化后的日期值
+ */
+function formatDateSingle({
   newDate,
   format,
-  dayjsLocale,
-  targetFormat,
+  dayjsLocale = 'zh-cn',
+  formatter,
+}: {
+  newDate: string | number | Date;
+  format: string;
+  dayjsLocale?: string;
+  formatter: (dayjsObj: any, format: string) => string | number | Date;
+}): string | number | Date {
+  if (newDate == null || newDate === '') return '';
+
+  const parsedDate = parseToDayjs(newDate, format).locale(dayjsLocale);
+
+  // 格式化失败提示
+  if (!parsedDate.isValid()) {
+    log.error(
+      'DatePicker',
+      `Check whether the format、value format is valid.\nformat: '${format}', value: '${newDate}'`
+    );
+    return '';
+  }
+
+  return formatter(parsedDate, format);
+}
+
+/**
+ * @description: 格式化日期 Range - 通用处理
+ * @param {Object} params - 参数对象
+ * @param {any[]} params.newDate - 输入的日期值数组
+ * @param {string} params.format - 默认日期格式
+ * @param {string} [params.dayjsLocale="zh-cn"] - dayjs 语言环境
+ * @param {boolean} [params.autoSwap] - 是否自动交换顺序以保证结束时间大于开始时间
+ * @param {Function} formatter - 格式化函数，接受 dayjs 对象和格式，返回格式化结果
+ * @returns {Array<string | number | Date>} 格式化后的日期值数组
+ */
+function formatDateRange({
+  newDate,
+  format,
+  dayjsLocale = 'zh-cn',
   autoSwap,
+  formatter,
 }: {
   newDate: any;
   format: string;
   dayjsLocale?: string;
-  targetFormat?: string;
   autoSwap?: boolean;
-}) {
+  formatter: (dayjsObj: any, format: string) => string | number | Date;
+}): Array<string | number | Date> {
   if (!newDate || !Array.isArray(newDate)) return [];
 
-  let dayjsDateList = newDate.map((d) => d && parseToDayjs(d, format).locale(dayjsLocale));
+  let dayjsDateList = newDate.map((d) => (d == null || d === '' ? null : parseToDayjs(d, format).locale(dayjsLocale)));
 
   // 保证后面的时间大于前面的时间
   if (
@@ -124,50 +171,97 @@ function formatRange({
   if (dayjsDateList.some((r) => r && !r.isValid())) {
     log.error(
       'DatePicker',
-      `Check whether the value、format、valueType format is valid.\nformat: '${format}' value: '${newDate}' valueType: '${targetFormat}'`
+      `Check whether the value、format format is valid.\nformat: '${format}', value: '${newDate}'`
     );
     return [];
   }
 
-  // valueType = 'time-stamp' 返回时间戳
-  if (targetFormat === 'time-stamp') return dayjsDateList.map((da) => da && da.toDate().getTime());
-  // valueType = 'Date' 返回时间对象
-  if (targetFormat === 'Date') return dayjsDateList.map((da) => da && da.toDate());
-
-  return dayjsDateList.map((da) => da && da.format(targetFormat || format));
+  return dayjsDateList.map((da) => da && formatter(da, format));
 }
 
-// 格式化单选
-function formatSingle({
-  newDate,
-  format,
-  targetFormat,
-  dayjsLocale,
-}: {
-  newDate: any;
-  format: string;
-  targetFormat?: string;
-  dayjsLocale?: string;
-}) {
-  if (!newDate) return '';
-
-  const dayJsDate = parseToDayjs(newDate, format).locale(dayjsLocale);
-
-  // 格式化失败提示
-  if (!dayJsDate.isValid()) {
-    log.error(
-      'DatePicker',
-      `Check whether the format、value format is valid.\nformat: '${format}' value: '${newDate}'`
-    );
-    return '';
+/**
+ * @description: Value 格式化日期 - 实际输出值
+ * @param {DateValue | DateValue[]} newDate
+ * @param {{ format: string; targetFormat?: string; dayjsLocale?: string; autoSwap?: boolean }} options
+ *  当 targetFormat 不存在时，输出 format 格式化的值
+ *  当 targetFormat = 'time-stamp' 时，输出时间戳
+ *  当 targetFormat = 'Date' 时，输出 Date 对象
+ * @return {string | number | Date | Array<string | number | Date>}
+ */
+export function formatValueDate(
+  newDate: DateValue | DateValue[],
+  {
+    format,
+    targetFormat,
+    dayjsLocale = 'zh-cn',
+    autoSwap,
+  }: {
+    format: string;
+    targetFormat?: string;
+    dayjsLocale?: string;
+    autoSwap?: boolean;
   }
+): string | number | Date | Array<string | number | Date> {
+  const parseFormat = targetFormat && targetFormat !== 'time-stamp' && targetFormat !== 'Date' ? targetFormat : format;
 
-  // valueType = 'time-stamp' 返回时间戳
-  if (targetFormat === 'time-stamp') return dayJsDate.toDate().getTime();
-  // valueType = 'Date' 返回时间对象
-  if (targetFormat === 'Date') return dayJsDate.toDate();
+  const valueFormatter = (da: any, fmt: string) => {
+    // valueType = 'time-stamp' 返回时间戳
+    if (targetFormat === 'time-stamp') return da.toDate().getTime();
+    // valueType = 'Date' 返回时间对象
+    if (targetFormat === 'Date') return da.toDate();
+    return da.format(fmt);
+  };
 
-  return dayJsDate.format(targetFormat || format);
+  if (Array.isArray(newDate)) {
+    return formatDateRange({
+      newDate,
+      format: parseFormat,
+      dayjsLocale,
+      autoSwap,
+      formatter: valueFormatter,
+    });
+  }
+  return formatDateSingle({
+    newDate,
+    format: parseFormat,
+    dayjsLocale,
+    formatter: valueFormatter,
+  });
+}
+
+/**
+ * @description: Display 格式化日期 - 展示值
+ * @param {DateValue | DateValue[]} newDate
+ * @param {{ format: string; dayjsLocale?: string; autoSwap?: boolean }} options
+ * @return {string | number | Date | Array<string | number | Date>}
+ */
+export function formatDisplayDate(
+  newDate: DateValue | DateValue[],
+  {
+    format,
+    dayjsLocale = 'zh-cn',
+    autoSwap,
+  }: {
+    format: string;
+    dayjsLocale?: string;
+    autoSwap?: boolean;
+  }
+): string | number | Date | Array<string | number | Date> {
+  if (Array.isArray(newDate)) {
+    return formatDateRange({
+      newDate,
+      format,
+      dayjsLocale,
+      autoSwap,
+      formatter: (da, fmt) => da.format(fmt),
+    });
+  }
+  return formatDateSingle({
+    newDate,
+    format,
+    dayjsLocale,
+    formatter: (da, fmt) => da.format(fmt),
+  });
 }
 
 // 检测日期是否合法
@@ -181,27 +275,6 @@ export function isValidDate(value: DateValue | DateValue[], format: string) {
 
   if (value === '') return true;
   return dayjs(value, format).isValid() || dayjs(value).isValid();
-}
-
-// 日期格式化
-export function formatDate(
-  newDate: DateValue | DateValue[],
-  {
-    format,
-    targetFormat,
-    dayjsLocale = 'zh-cn',
-    autoSwap,
-  }: { format: string; dayjsLocale?: string, targetFormat?: string; autoSwap?: boolean }
-) {
-  let result;
-
-  if (Array.isArray(newDate)) {
-    result = formatRange({ newDate, format, dayjsLocale, targetFormat, autoSwap });
-  } else {
-    result = formatSingle({ newDate, format, dayjsLocale, targetFormat });
-  }
-
-  return result;
 }
 
 // 对齐格式化时间
@@ -240,11 +313,13 @@ export function getDefaultFormat({
   format,
   valueType,
   enableTimePicker,
+  defaultTime,
 }: {
   mode?: string;
   format?: string;
   valueType?: string;
   enableTimePicker?: boolean;
+  defaultTime?: string | string[];
 }) {
   if (mode === 'year') {
     return {
@@ -275,10 +350,12 @@ export function getDefaultFormat({
     };
   }
   if (mode === 'date') {
+    const hasTime = enableTimePicker || !!defaultTime;
+
     return {
-      format: format || `YYYY-MM-DD${enableTimePicker ? ' HH:mm:ss' : ''}`,
-      valueType: valueType || format || `YYYY-MM-DD${enableTimePicker ? ' HH:mm:ss' : ''}`,
-      timeFormat: extractTimeFormat(format || `YYYY-MM-DD${enableTimePicker ? ' HH:mm:ss' : ''}`) || TIME_FORMAT,
+      format: format || `YYYY-MM-DD${hasTime ? ' HH:mm:ss' : ''}`,
+      valueType: valueType || format || `YYYY-MM-DD${hasTime ? ' HH:mm:ss' : ''}`,
+      timeFormat: extractTimeFormat(format || `YYYY-MM-DD${hasTime ? ' HH:mm:ss' : ''}`) || TIME_FORMAT,
     };
   }
   log.error('DatePicker', `Invalid mode: ${mode}`);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

目前 datepicker 内的格式化逻辑是，先用参数 `foramt` 进行格式化为标准 dayjs，然后再进行判断是否是使用了 `valueType`，再进行格式化。

1. 场景一
 当用户在 <t-date-picker>` 上使用了 `format='YYYY'` 后，使用 `valueType='YYDDMM'`，这里会导致 `onChange` 失去后面的月份和天数。
 2. 场景二
 当用户在 <t-date-picker default-time='02:00:00'>` 上使用了 `format='YYDDMM'` 后，使用 `valueType='time-stamp'`，这里会导致时间戳只有年月日之后的时间，而丢失了`default-time`。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refactor(date-picker): 将 `format` 与 `valueType` 分离

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
