### PR TITLE
feat(Upload): optimize the logic for determining if a file is duplicated

### DIFF
--- a/js/upload/main.ts
+++ b/js/upload/main.ts
@@ -341,12 +341,15 @@ export function formatToUploadFile(
 export function validateFile(
   params: FileChangeParams
 ): Promise<FileChangeReturn> {
-  const { files, uploadValue, max, allowUploadDuplicateFile } = params;
+  const { files, uploadValue, max, allowUploadDuplicateFile, capture = '' } = params;
   return new Promise((resolve) => {
     // 是否允许相同的文件名存在
     let tmpFiles = files.filter((file) => {
+      // capture 明确指定后，一定是调用设备的媒体设备（比如：摄像头）捕获上传文件，该类文件跳过重复文件名校验
+      if (allowUploadDuplicateFile || !!capture) return true;
+
       const sameNameFile = uploadValue.find((t) => t.name === file.name);
-      return allowUploadDuplicateFile || !sameNameFile;
+      return !sameNameFile;
     });
 
     let hasSameNameFile = false;

--- a/js/upload/types.ts
+++ b/js/upload/types.ts
@@ -145,6 +145,8 @@ export interface FileChangeParams {
   uploadValue: UploadFile[];
   /** 是否允许重复上传相同文件名的文件 */
   allowUploadDuplicateFile?: boolean
+  /** 调用摄像头捕获文件 */
+  capture?: string;
   /** 文件上传的数量不超过 max */
   max?: number;
   /** 图片文件大小限制 */


### PR DESCRIPTION
### 背景
- 移动端拍照上传，通常会生成相同的文件名（比如 image.jpg 或类似的默认名称），导致第二张照片（后序拍照上传文件）被同名文件验证逻辑过滤掉

issues: https://github.com/Tencent/tdesign-mobile-vue/issues/1641
### 分析
>  <input type="file">
- 1. 当 capture 被明确指定值，一定是通过调用设备的媒体设备（比如：摄像头）捕获上传文件，该类文件跳过重复文件名校验
- 2. capture 未被启用，此时移动端有 本地文件/本地图册/拍照 三种途径获取上传文件，无法判断文件是否为拍照上传

### 方案
- 1.  validateFile() 中补充 capture 参数， 对于通过调用设备的媒体设备上传的文件，跳过文件名重复检测
- 2. 移动端API文档中，补充 allowUploadDuplicateFile  属性的描述，对于未使用 capture 属性 + 拍照上传的情况，allowUploadDuplicateFile 应直接用 true， 避免拍照上传的文件被同名文件校验过滤  https://github.com/TDesignOteam/tdesign-api/pull/777
