### PR TITLE
fix(DropdownItem): fix icon spacing error

### DIFF
--- a/style/mobile/components/dropdown-menu/_index.less
+++ b/style/mobile/components/dropdown-menu/_index.less
@@ -34,6 +34,7 @@
     align-items: center;
     font-size: @dropdown-menu-icon-size;
     transition: transform 240ms ease;
+    margin-left: 4px;
 
     &--active {
       transform: rotate(180deg);


### PR DESCRIPTION
### DropdownItem(h5)
- 修复图标左间距错误

> <img width="400" height="260" alt="截屏2025-11-19 21 46 46" src="https://github.com/user-attachments/assets/a8ce61b4-1376-484d-a34e-5060feaf7772" />
