### PR TITLE
fix(Input): fix auto-width incorrect first render result in Safari

### DIFF
--- a/style/web/components/input/_index.less
+++ b/style/web/components/input/_index.less
@@ -336,6 +336,9 @@
 .@{prefix}-input--auto-width {
   width: fit-content;
   min-width: 60px;
+  .@{prefix}-input {
+    width: fit-content;
+  }
 }
 
 // 字数限制数字


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

外层 fit-content 内层 100% 子元素 flex: 1 导致在 safari 出现异常渲染，宽度无法正确计算
<img width="1207" height="854" alt="企业微信截图_e4533a5f-f33d-4f34-8657-c00c67161323" src="https://github.com/user-attachments/assets/aa416b5e-3f6a-4017-8d95-4335367d3060" />


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 修正 input 及上层 select 等组件在 safari 中初次渲染 auto-width 失效的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
