### PR TITLE
style(Select): adjusting the style priority of select-option span

### DIFF
--- a/style/web/components/select/_index.less
+++ b/style/web/components/select/_index.less
@@ -174,7 +174,7 @@
   transition: background-color @anim-duration-base @anim-time-fn-easing;
   box-sizing: border-box;
 
-  span {
+  > span {
     position: relative;
     .text-ellipsis();
   }

--- a/style/web/components/select/_index.less
+++ b/style/web/components/select/_index.less
@@ -176,6 +176,7 @@
 
   > span {
     position: relative;
+    display: block;
     .text-ellipsis();
   }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
- adjusting the style priority of select-option span and add `display:block`

### 问题：

`Select` 下拉组件为啥要包一层 `span`，宽度就丢失了，做自定义样式的时候只能强行覆盖样式

<img width="1581" height="373" alt="image" src="https://github.com/user-attachments/assets/46c77eaf-426f-433c-828f-aefc4a530390" />

### 解决：

调整 `.t-select-option span` 的样式优先级和添加 `display:block`

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- style(Select): 调整 `.t-select-option span` 的样式优先级和添加 `display:block`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
