### PR TITLE
fix(avatar): fix image z-index

### DIFF
--- a/style/web/components/avatar/_index.less
+++ b/style/web/components/avatar/_index.less
@@ -41,6 +41,7 @@
   > .@{prefix}-image__wrapper {
     max-width: 100%;
     max-height: 100%;
+    z-index: inherit;
   }
 }
 

--- a/style/web/components/avatar/_index.less
+++ b/style/web/components/avatar/_index.less
@@ -50,7 +50,7 @@
   align-items: center;
 
   .@{prefix}-avatar {
-    border: 2px solid @avatar-border-color;
+    border: 1px solid @avatar-border-color;
   }
 
   &.@{prefix}-avatar--offset-right {

--- a/style/web/components/avatar/_var.less
+++ b/style/web/components/avatar/_var.less
@@ -23,8 +23,8 @@
 @avatar-border-color: @bg-color-container;
 
 //组合头像偏移量
-@avatar-group-offset-small: calc(0px - @size-2);
-@avatar-group-offset-medium: calc(0px - @size-3);
+@avatar-group-offset-small: calc(0px - @size-4);
+@avatar-group-offset-medium: calc(0px - @size-4);
 @avatar-group-offset-large: calc(0px - @size-4);
 
 //z-index

--- a/style/web/components/avatar/_var.less
+++ b/style/web/components/avatar/_var.less
@@ -23,8 +23,8 @@
 @avatar-border-color: @bg-color-container;
 
 //组合头像偏移量
-@avatar-group-offset-small: calc(0px - @size-4);
-@avatar-group-offset-medium: calc(0px - @size-4);
+@avatar-group-offset-small: calc(0px - @size-2);
+@avatar-group-offset-medium: calc(0px - @size-3);
 @avatar-group-offset-large: calc(0px - @size-4);
 
 //z-index


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
设计稿
<img width="2972" height="1054" alt="image" src="https://github.com/user-attachments/assets/19465228-90a7-492e-8d54-9981447ec849" />


层级改前
<img width="2016" height="714" alt="image" src="https://github.com/user-attachments/assets/e89b7a90-7716-433f-ba75-21edf630b96f" />
层级改后
<img width="1720" height="686" alt="image" src="https://github.com/user-attachments/assets/692a9d00-c061-4c5e-a9ff-5b000308e7eb" />


头像间空白间隙1px
改前
<img width="1002" height="710" alt="image" src="https://github.com/user-attachments/assets/4682f459-0f2e-4624-b8b8-68cd06e671a6" />
改后
<img width="5388" height="950" alt="image" src="https://github.com/user-attachments/assets/89a00e65-b557-4d71-8f4a-b987696f562c" />


这里需要看下，以哪个为准
 offset 设计稿统一是8px，
样式实现是
```
@avatar-group-offset-small: calc(0px - @size-2);
@avatar-group-offset-medium: calc(0px - @size-3);
@avatar-group-offset-large: calc(0px - @size-4);
```


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Avatar): 修复头像组层叠关系，右侧图片在上图片层级展示错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
