### PR TITLE
fix(fake-arrow):  修复旋转箭头在safari  无法旋转

### DIFF
--- a/js/utils/helper.ts
+++ b/js/utils/helper.ts
@@ -257,3 +257,9 @@ export function calculateNodeSize(targetElement: HTMLElement) {
     sizingStyle,
   };
 }
+
+export function isSafari(): boolean {
+  if (typeof navigator === 'undefined' || !navigator) return false;
+  const ua = navigator.userAgent;
+  return /Safari/.test(ua) && !/Chrome/.test(ua);
+}

--- a/js/utils/helper.ts
+++ b/js/utils/helper.ts
@@ -259,7 +259,6 @@ export function calculateNodeSize(targetElement: HTMLElement) {
 }
 
 export function isSafari(): boolean {
-  if (typeof navigator === 'undefined' || !navigator) return false;
-  const ua = navigator.userAgent;
+  const ua = window?.navigator?.userAgent;
   return /Safari/.test(ua) && !/Chrome/.test(ua);
 }

--- a/style/web/_global.less
+++ b/style/web/_global.less
@@ -37,7 +37,6 @@
   path {
     transition: transform @anim-duration-base;
     transform-origin: center;
-    stroke: currentcolor;
   }
   &.@{prefix}-fake-arrow--active {
     path {

--- a/style/web/_global.less
+++ b/style/web/_global.less
@@ -20,13 +20,14 @@
 // 统一的可旋转箭头
 .@{prefix}-fake-arrow {
   path {
-    transition: d @anim-duration-base;
+    transition: transform @anim-duration-base;
     stroke: currentcolor;
+    transform-origin: center;
   }
 
   &--active {
     path {
-      d: path('M3.75 10.2002L7.99274 5.7998L12.2361 10.0425');
+      transform: rotate(180deg);
     }
   }
 }

--- a/style/web/_global.less
+++ b/style/web/_global.less
@@ -20,15 +20,29 @@
 // 统一的可旋转箭头
 .@{prefix}-fake-arrow {
   path {
-    transition: transform @anim-duration-base;
+    transition: d @anim-duration-base;
     stroke: currentcolor;
-    transform-origin: center;
   }
 
   &--active {
     path {
-      transform: scaleY(-1);
+      d: path('M3.75 10.2002L7.99274 5.7998L12.2361 10.0425');
     }
+  }
+}
+
+// Safari 兼容方案: 使用 transform 而非 d 动画
+// Safari 不支持对 path 的 d 属性进行动画
+.@{prefix}-fake-arrow.@{prefix}-fake-arrow--transform {
+   path {
+    transition: transform @anim-duration-base;
+    transform-origin: center;
+    stroke: currentcolor;
+   }
+  &.@{prefix}-fake-arrow--active {
+     path {
+      transform: scaleY(-1);
+     }
   }
 }
 

--- a/style/web/_global.less
+++ b/style/web/_global.less
@@ -34,15 +34,15 @@
 // Safari 兼容方案: 使用 transform 而非 d 动画
 // Safari 不支持对 path 的 d 属性进行动画
 .@{prefix}-fake-arrow.@{prefix}-fake-arrow--transform {
-   path {
+  path {
     transition: transform @anim-duration-base;
     transform-origin: center;
     stroke: currentcolor;
-   }
+  }
   &.@{prefix}-fake-arrow--active {
-     path {
+    path {
       transform: scaleY(-1);
-     }
+    }
   }
 }
 

--- a/style/web/_global.less
+++ b/style/web/_global.less
@@ -27,7 +27,7 @@
 
   &--active {
     path {
-      transform: rotate(180deg);
+      transform: scaleY(-1);
     }
   }
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue-next/issues/6290

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题原因：

原代码使用了 d: path('M3.75 10.2002L7.99274 5.7998L12.2361 10.0425');
CSS path() 函数在某些版本的 Safari 中支持不完整，特别是用于动态更改 SVG path 数据时
解决方案：

移除了不兼容的 path() 函数和 d 属性动画
改用 transform: scaleY(-1)  实现箭头翻转效果
保持了相同视觉效果，但使用更广泛支持的 CSS transform 属性
添加了 transform-origin: center 确保旋转中心正确
兼容性提升：

transform: scaleY(-1) 适配所有现代浏览器（含Safari），兼容性优异；实现垂直翻转效果更流畅稳定，且完全保留组件原有交互体验。


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Menu): 在 `safari` 浏览器中点击展开图标没有变化

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
