### PR TITLE
fix(inputNumber): 修复大数计算异常清除前导零错误

### DIFF
--- a/js/input-number/large-number.ts
+++ b/js/input-number/large-number.ts
@@ -208,12 +208,12 @@ export function compareNumber(num1: string | number, num2: string | number, larg
 export function largeIntegerNumberSubtract(
   num1: string,
   num2: string,
-  p?: { decimal?: boolean; stayZero?: boolean }
+  p?: { decimal?: boolean; stayZero?: boolean; filledZero?: boolean }
 ): string {
   if (num1 === num2) return '0';
-  const { decimal, stayZero } = p || {};
-  const number1 = removeInvalidZero(num1);
-  const number2 = removeInvalidZero(num2);
+  const { decimal, stayZero, filledZero } = p || {};
+  const number1 = filledZero ? num1 : removeInvalidZero(num1, decimal);
+  const number2 = filledZero ? num2 : removeInvalidZero(num2, decimal);
   const isFirstLarger = compareLargeIntegerNumber(number1, number2) > 0;
   const maxNumber = isFirstLarger ? number1 : number2;
   const minNumber = isFirstLarger ? number2 : number1;
@@ -239,7 +239,7 @@ export function largeIntegerNumberSubtract(
   if (!stayZero) {
     finalNumber = finalNumber.replace(/^0+/, '');
   }
-  return removeInvalidZero(isFirstLarger ? finalNumber : `-${finalNumber}`);
+  return removeInvalidZero(isFirstLarger ? finalNumber : `-${finalNumber}`, decimal);
 }
 
 /**
@@ -264,15 +264,20 @@ export function largePositiveNumberSubtract(num1: string, num2: string): string 
   // 小数点相减
   let decimalNumber = '';
   let addOneNumber = decimalNumber1;
+  const isNumber1Short = decimalNumber1.length < decimalNumber2.length;
   // 第一个数字的小数位数比第二个少，需补足 0
-  if (decimalNumber1.length < decimalNumber2.length) {
+  if (isNumber1Short) {
     addOneNumber = `${decimalNumber1}${fillZero(decimalNumber2.length - decimalNumber1.length)}`;
   }
-  // 第一个小数位更小，是否需要借位
+  // 第一个小数位是否更大，不需要借位
   if (compareLargeDecimalNumber(addOneNumber, decimalNumber2) >= 0) {
-    decimalNumber = largeIntegerNumberSubtract(addOneNumber, decimalNumber2, { decimal: true });
+    decimalNumber = largeIntegerNumberSubtract(addOneNumber, decimalNumber2, {
+      decimal: true,
+      stayZero: true,
+      filledZero: true,
+    });
   } else {
-    if (decimalNumber1.length < decimalNumber2.length || decimalNumber1 === '0') {
+    if (isNumber1Short || decimalNumber1 === '0') {
       decimalNumber = largeIntegerNumberSubtract(`1${addOneNumber}`, decimalNumber2, { stayZero: true });
       decimalNumber = fillZero(decimalNumber2.length - decimalNumber.length) + decimalNumber;
     } else {

--- a/test/unit/input-number/largeNumberSubtract.test.js
+++ b/test/unit/input-number/largeNumberSubtract.test.js
@@ -113,4 +113,12 @@ describe('largeNumberSubtract', () => {
   it('0.222222222 - 0.3', () => {
     expect(largeNumberSubtract('0.222222222', '0.3')).toBe(String(-0.077777778));
   });
+
+  it('-0.222222222 - (-0.3)', () => {
+    expect(largeNumberSubtract('-0.222222222', '-0.3')).toBe(String(0.077777778));
+  });
+
+  it('-0.222222222 - (-0.000000001)', () => {
+    expect(largeNumberSubtract('-0.222222222', '-0.000000001')).toBe(String(-0.222222221));
+  });
 });

--- a/test/unit/input-number/largeNumberSubtract.test.js
+++ b/test/unit/input-number/largeNumberSubtract.test.js
@@ -105,4 +105,12 @@ describe('largeNumberSubtract', () => {
   it('0.1 - (-0.2)', () => {
     expect(largeNumberSubtract('0.1', '-0.2')).toBe(String(0.3));
   });
+
+  it('0.222222222 - 0.000000001', () => {
+    expect(largeNumberSubtract('0.222222222', '0.000000001')).toBe(String(0.222222221));
+  });
+
+  it('0.222222222 - 0.3', () => {
+    expect(largeNumberSubtract('0.222222222', '0.3')).toBe(String(-0.077777778));
+  });
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Tencent/tdesign-react#4073

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

`tdesign-react` 库中 `InputNumber` 组件使用 `largeNumber` 选项时，设置形似 `0.000000001` 的 step 时计算减法会被异常清除前导零，导致计算错误。

- 优化了参数传递，同时新增 `filledZero` 参数用于在已补零的情况下跳过处理
- 新增了测试案例覆盖

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(inputNumber): 修复大数计算前导零被错误清除的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
