### PR TITLE
fix(Tabs): fix icon size error

### DIFF
--- a/style/mobile/components/tabs/_index.less
+++ b/style/mobile/components/tabs/_index.less
@@ -140,6 +140,7 @@
   }
 
   &__icon {
+    display: flex;
     font-size: @tab-icon-size;
     margin-right: 2px;
   }

--- a/style/mobile/components/tabs/_var.less
+++ b/style/mobile/components/tabs/_var.less
@@ -26,4 +26,4 @@
 @tab-item-tag-bg: var(--td-tab-item-tag-bg, @bg-color-secondarycontainer);
 @tab-item-tag-active-bg: var(--td-tab-item-tag-active-bg, @brand-color-light);
 
-@tab-icon-size: var(--td-tab-icon-size, 16px);
+@tab-icon-size: var(--td-tab-icon-size, 18px);


### PR DESCRIPTION
### 移动端 Tabs

- 图标默认尺寸为 18px
- <img width="400" height="395" alt="企业微信截图_25aa4f97-6145-4990-93fd-f06749742945" src="https://github.com/user-attachments/assets/4fda9b4a-b894-4f78-b444-6ddfda536f66" />
