### PR TITLE
fix(Tabs): fix insufficient split divider line length in scrollable scenarios,

### DIFF
--- a/style/mobile/components/tabs/_index.less
+++ b/style/mobile/components/tabs/_index.less
@@ -156,6 +156,10 @@
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
+
+    &--split {
+      .border(bottom, @tab-border-color);
+    }
   }
 
   &__track {
@@ -191,10 +195,6 @@
       background: @bg-color-secondarycontainer;
 
       --td-tab-border-color: transparent;
-    }
-
-    &--split {
-      .border(bottom, @tab-border-color);
     }
   }
 


### PR DESCRIPTION
### 移动端 Tabs
- 修复 `split` 分割线在可滚动场景下长度不足

### 问题

<img width="479" height="176" alt="截屏2026-03-24 20 12 47" src="https://github.com/user-attachments/assets/5efba024-4a36-4831-8a3b-dc10e1700406" />
