### PR TITLE
fix(Typography): fixed spacing errors for copied icons

### DIFF
--- a/style/mobile/components/typography/_index.less
+++ b/style/mobile/components/typography/_index.less
@@ -102,6 +102,10 @@
     color: @typography-text-secondary-color;
   }
 
+  &__copy:not(:empty) {
+    margin: 0 4px;
+  }
+
   &-ellipsis-symbol,
   .t-icon-copy {
     color: @typography-icon-color;


### PR DESCRIPTION
### 移动端 Typography 组件
- 修复复制图标间距错误
> 
<img width="400" alt="截屏2026-05-07 11 56 25" src="https://github.com/user-attachments/assets/e014f974-7267-4e55-8038-2aa2c3c19430" />
