### PR TITLE
fix(input-number): handle empty value changed to zero

### DIFF
--- a/js/input-number/number.ts
+++ b/js/input-number/number.ts
@@ -217,8 +217,11 @@ export function canInputNumber(number: string | undefined | null, largeNumber?: 
 /**
  * 是否允许设置组件新值，触发 onChange 事件
  */
-export function canSetValue(number: string, lastNumber: number) {
-  return parseFloat(number) !== lastNumber && !Number.isNaN(Number(number));
+export function canSetValue(number: string, lastNumber?: NumberType | null) {
+  if (Number.isNaN(Number(number))) return false;
+  if (lastNumber === '' || lastNumber === null || isUndefined(lastNumber)) return number !== '';
+  if (number === '') return true;
+  return parseFloat(number) !== Number(lastNumber);
 }
 
 /**

--- a/test/unit/input-number/number.test.js
+++ b/test/unit/input-number/number.test.js
@@ -213,6 +213,11 @@ it('canSetValue', () => {
   expect(canSetValue('2.00', 2)).toBe(false);
   expect(canSetValue('2.3e', 2.3)).toBe(false);
   expect(canSetValue('2.3e10', 2.3)).toBe(true);
+  expect(canSetValue('0', '')).toBe(true);
+  expect(canSetValue('0', null)).toBe(true);
+  expect(canSetValue('0', undefined)).toBe(true);
+  expect(canSetValue('', '')).toBe(false);
+  expect(canSetValue('', 0)).toBe(true);
 });
 
 describe('formatUnCompleteNumber', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Fixes #6670

### 💡 需求背景和解决方案

当 `InputNumber` 绑定值为 空字符串 `''` 时，用户输入 `0` 不会触发 `change` 事件。

原因是输入变更判断时将旧值通过 `Number('')` 转换成了 `0`，导致从 `''` 输入到 `0` 被误判为值未变化。

本次修复调整了 `canSetValue` 的比较逻辑，保留 `''`、`null`、`undefined` 等空值语义，避免在比较前把空字符串转换为 `0`。同时在组件输入逻辑中使用原始旧值参与判断，确保从空字符串输入 `0` 时可以正常触发 `change`。

本次改动不涉及 API 变更，也不涉及 UI/交互样式变更。

已补充测试用例：

- `InputNumber` 从空字符串输入 `0` 时触发 `change`
- `canSetValue` 对空字符串、`null`、`undefined` 到 `0` 的判断

### 📝 更新日志

- fix(InputNumber): 修复初始值为空字符串时输入 0 不触发 change 的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
