### PR TITLE
fix(Tree): missing drop indicator when dragging above a disabled node

### DIFF
--- a/style/web/components/tree/_index.less
+++ b/style/web/components/tree/_index.less
@@ -133,30 +133,31 @@
         background-color: @tree-node-bg-hover-color;
         background-clip: content-box;
       }
+    }
 
-      &::after {
-        position: absolute;
-        top: -(@tree-node-drag-tip-height / 2);
-        right: 0;
-        left: 0;
-        display: block;
-        height: @tree-node-drag-tip-height;
-        border-radius: (@tree-node-drag-tip-height / 2);
-        content: '';
-        padding: inherit;
-        background-clip: content-box;
-      }
+    &::after {
+      position: absolute;
+      top: -(@tree-node-drag-tip-height / 2);
+      right: 0;
+      left: 0;
+      display: block;
+      height: 0;
+      border-radius: (@tree-node-drag-tip-height / 2);
+      content: '';
+      padding: inherit;
+      background-clip: content-box;
     }
 
     &--tip {
-      &-top::after {
+      &-top::after,
+      &-bottom::after {
+        height: @tree-node-drag-tip-height;
         background-color: @tree-node-drag-tip-bg;
       }
 
       &-bottom::after {
         top: unset;
         bottom: -(@tree-node-drag-tip-height / 2);
-        background-color: @tree-node-drag-tip-bg;
       }
 
       &-highlight {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-common/issues/2501

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

disabled 节点不带 `--draggable` 类，导致没有 ::after 伪元素
`--tip-top::after { background-color: ... }` 选中了一个不存在/没有定位的伪元素，因此高亮线不显示

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): 修复可拖拽节点拖至禁用节点上下方时提示线未正确显示的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
