### PR TITLE
fix(tag-input): align input content vertically / 修复输入内容垂直对齐

### DIFF
--- a/style/web/components/tag-input/_index.less
+++ b/style/web/components/tag-input/_index.less
@@ -109,6 +109,10 @@
       text-align: left;
     }
 
+    .@{prefix}-input__inner {
+      vertical-align: middle;
+    }
+
     .@{prefix}-input__suffix-icon {
       position: absolute;
       bottom: 0;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复 / Bug fix
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进 / Component style or interaction improvement
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<img width="2134" height="242" alt="image" src="https://github.com/user-attachments/assets/b4ae480b-2646-4f7c-8561-916b79d08c69" />

- https://tdesign.tencent.com/react/components/tag-input#标签数量超出的输入框

### 💡 需求背景和解决方案

- https://preview-tdesign-react-pr-2564-tdesign-common.surge.sh/react/components/tag-input#标签数量超出的输入框

中文：TagInput 在 `break-line` 且已有 tag 时，`.t-input` 会切换到 block/inline 混合布局。此时真实 `.t-input__inner` 使用默认 baseline 对齐，和 label/tag 的 `vertical-align: middle` 不一致，导致带 label 的基础示例里 label、tag、输入内容视觉上存在轻微垂直偏差。

English: When TagInput has tags in `break-line` mode, `.t-input` switches to a mixed block/inline layout. The real `.t-input__inner` kept the default baseline alignment, while the label and tags were vertically aligned to the middle, causing a slight visual vertical offset in labeled TagInput examples.

中文：本 PR 仅在 `tag-input` 的 `break-line + 非空` 场景下为 `.t-input__inner` 补充 `vertical-align: middle`，使输入内容与 label/tag 保持一致的垂直居中，不影响 scroll 模式、空值状态和 Input 通用样式。

English: This PR adds `vertical-align: middle` to `.t-input__inner` only for non-empty TagInput in `break-line` mode, aligning the input content with labels and tags without affecting scroll mode, empty state, or generic Input styles.

### 📝 更新日志

- fix(TagInput): 修复带 label 且已有 tag 时输入内容垂直对齐偏差

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充 / Documentation added or not needed
- [x] 代码演示已提供或无须提供 / Demo added or not needed
- [x] TypeScript 定义已补充或无须补充 / TypeScript definitions added or not needed
- [x] Changelog 已提供或无须提供 / Changelog provided or not needed

### ✅ 验证 / Verification

- 中文：在 tdesign-react 本地站点中验证，基础示例 Controlled / UnControlled 行的 label、tag、输入内容中心偏差为 0px；输入态也为 0px。
- English: Verified in the local tdesign-react docs site. The label, tag, and input centers are aligned with 0px offset in the Controlled / UnControlled basic examples, including the typing state.
