### PR TITLE
fix(locale): incorrect content of datePicker.now

### DIFF
--- a/js/global-config/locale/ja_JP.ts
+++ b/js/global-config/locale/ja_JP.ts
@@ -117,7 +117,7 @@ export default {
     preMonth: '先月',
     preDecade: '過去10年間',
     nextDecade: '次の10年',
-    now: '電流',
+    now: '現在',
   },
   upload: {
     sizeLimitMessage: '画像サイズは最大で {sizeLimit}',


### PR DESCRIPTION
### Summary

`datePicker.now` in the Japanese locale is `電流`, which is the word for *electric current* (electricity), not the present time. It looks like the English source string "Now" was mistranslated through the "current" homograph.

The same key in the sibling locales all carry the intended now/current meaning:

| locale | `datePicker.now` |
| --- | --- |
| en_US | `Now` |
| zh_CN | `当前` |
| ko_KR | `현재의` |
| ja_JP (before) | `電流` (electric current) |

This changes it to `現在`, the standard Japanese word for "present/now", to match the other locales. Only that one string is touched.
