### PR TITLE
fix(locale): add upload reload text for mobile locales

### DIFF
--- a/js/global-config/mobile/locale/ar_KW.ts
+++ b/js/global-config/mobile/locale/ar_KW.ts
@@ -115,7 +115,7 @@ export default {
       waitingText: 'الانتظار',
       failText: 'فشل',
       successText: 'النجاح',
-      reloadText: 'إعادة التحميل',
+      reloadText: 'إعادة الرفع',
     },
   },
   guide: {

--- a/js/global-config/mobile/locale/ar_KW.ts
+++ b/js/global-config/mobile/locale/ar_KW.ts
@@ -115,6 +115,7 @@ export default {
       waitingText: 'الانتظار',
       failText: 'فشل',
       successText: 'النجاح',
+      reloadText: 'إعادة التحميل',
     },
   },
   guide: {

--- a/js/global-config/mobile/locale/it_IT.ts
+++ b/js/global-config/mobile/locale/it_IT.ts
@@ -103,6 +103,7 @@ export default {
       waitingText: 'Attesa',
       failText: 'Fallito',
       successText: 'Successo',
+      reloadText: 'Ricarica',
     },
   },
   guide: {

--- a/js/global-config/mobile/locale/ja_JP.ts
+++ b/js/global-config/mobile/locale/ja_JP.ts
@@ -90,6 +90,7 @@ export default {
       waitingText: '待機中',
       failText: '失敗しました',
       successText: '成功しました',
+      reloadText: '再試行',
     },
   },
   guide: {

--- a/js/global-config/mobile/locale/ja_JP.ts
+++ b/js/global-config/mobile/locale/ja_JP.ts
@@ -90,7 +90,7 @@ export default {
       waitingText: '待機中',
       failText: '失敗しました',
       successText: '成功しました',
-      reloadText: '再試行',
+      reloadText: '再アップロード',
     },
   },
   guide: {

--- a/js/global-config/mobile/locale/ko_KR.ts
+++ b/js/global-config/mobile/locale/ko_KR.ts
@@ -90,6 +90,7 @@ export default {
       waitingText: '대기 중',
       failText: '실패했습니다',
       successText: '성공했습니다',
+      reloadText: '다시 업로드',
     },
   },
   guide: {

--- a/js/global-config/mobile/locale/ru_RU.ts
+++ b/js/global-config/mobile/locale/ru_RU.ts
@@ -115,6 +115,7 @@ export default {
       waitingText: 'Ожидание загрузки',
       failText: 'Ошибка загрузки',
       successText: 'Загрузка завершена',
+      reloadText: 'Загрузить повторно',
     },
   },
   guide: {

--- a/js/global-config/mobile/locale/zh_TW.ts
+++ b/js/global-config/mobile/locale/zh_TW.ts
@@ -90,6 +90,7 @@ export default {
       waitingText: '待上傳',
       failText: '上傳失敗',
       successText: '上傳成功',
+      reloadText: '重新上傳',
     },
   },
   guide: {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

`upload.progress.reloadText` 是 mobile locale config type 中要求的字段，但部分 mobile locale 文件缺少该字段。这会导致下游触发 TypeScript 类型错误

```ts
  The types of 'upload.progress' are incompatible between these types.
    Property 'reloadText' is missing in type '{ uploadingText: string; waitingText: string; failText: string; successText: string; }' but required in type '{ uploadingText: string; waitingText: string; failText: string; successText: string; reloadText: string; }'.

177                 this.tdesignLanguageConfig= jaConfig;
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/tdesign-mobile-vue/es/_common/js/global-config/mobile/locale/zh_CN.d.ts:88:13
    88             reloadText: string;
                   ~~~~~~~~~~
    'reloadText' is declared here.
```


### 📝 更新日志

- fix(ConfigProvider): 为 `Upload` 语言包补充 `upload.progress.reloadText` 字段
- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
