### PR TITLE
feat(descriptions): improve borderless layout aesthetics

### DIFF
--- a/style/web/components/descriptions/_index.less
+++ b/style/web/components/descriptions/_index.less
@@ -28,7 +28,10 @@
     .generate-padding(s, @descriptions-borderless-padding-s);
 
     & @{root}__label {
-      color: @text-color-placeholder;
+      color: @descriptions-item-label-color;
+      min-width: @descriptions-item-label-min-width;
+      vertical-align: top;
+      white-space: nowrap;
     }
 
     &--fixed {
@@ -59,7 +62,7 @@
 
     :not(&--fixed):not(&--border) {
       @{root}__label {
-        padding-right: @comp-paddingLR-l;
+        padding-right: @descriptions-item-label-gap;
       }
     }
   }

--- a/style/web/components/descriptions/_var.less
+++ b/style/web/components/descriptions/_var.less
@@ -8,8 +8,17 @@
 
 // 无边框间距
 @descriptions-borderless-padding-l: @comp-paddingTB-l 0;
-@descriptions-borderless-padding-m: @comp-paddingTB-m 0;
-@descriptions-borderless-padding-s: @comp-paddingTB-s 0;
+@descriptions-borderless-padding-m: @comp-paddingTB-l 0;
+@descriptions-borderless-padding-s: @comp-paddingTB-m 0;
+
+// label 与 content 之间的间距（无边框模式）
+@descriptions-item-label-gap: @comp-paddingLR-l;
+
+// label 最小宽度：保证多列同一行的 label 结束边视觉对齐
+@descriptions-item-label-min-width: 96px;
+
+// label 颜色：从 placeholder 上调一档，视觉可识别为字段名
+@descriptions-item-label-color: @text-color-secondary;
 
 // border
 @descriptions-td-border: 1px solid @component-border;


### PR DESCRIPTION
- add label min-width to align label endings across columns
- add label gap and color tokens for better visual hierarchy
- adjust borderless padding for improved vertical rhythm

close #2431

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

close https://github.com/Tencent/tdesign-vue-next/issues/2431

### 💡 需求背景和解决方案

**问题**：Descriptions 组件在无边框模式下存在三处美感缺陷，导致视觉与 antd / element-plus 差距明显：

1. label 列没有统一最小宽度，多列布局下每行 label 结束边不对齐，视觉错乱。
2. label 使用 `@text-color-placeholder` 过淡，识别度弱，不像"字段名"。
3. `size=m/s` 上下 padding 过小，行与行贴太近，缺少呼吸感。

**方案**：仅修改 `style/web/components/descriptions` 下的样式与变量，向前兼容，不改 API：

- `_var.less` 新增三个 token：
  - `@descriptions-item-label-min-width: 96px`（label 最小宽度）
  - `@descriptions-item-label-gap: @comp-paddingLR-l`（label 与 content 间距）
  - `@descriptions-item-label-color: @text-color-secondary`（label 颜色上调一档）
- `_var.less` 调整无边框 padding：`m` 上调到 `@comp-paddingTB-l 0`，`s` 上调到 `@comp-paddingTB-m 0`。
- `_index.less` 让 label 应用 `min-width` / `vertical-align: top` / `white-space: nowrap`；无边框分支用新 gap token。

**兼容性**：有边框模式（`bordered`）不受影响；`fixed` 与 `column` 用法不受影响；仅视觉密度与 label 视觉权重发生变化。

### 📝 更新日志

- style(descriptions): 优化无边框模式下多列 label 结束边对齐、label 颜色识别度与行间距，提升视觉美感

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
