### PR TITLE
feat(switch): support square and line shape variants

### DIFF
--- a/style/web/components/switch/_index.less
+++ b/style/web/components/switch/_index.less
@@ -271,3 +271,95 @@
     }
   }
 }
+
+// shape: square - 圆角矩形外观
+.@{prefix}-switch--shape-square {
+  border-radius: @switch-shape-square-border-radius;
+
+  &.@{prefix}-size-l,
+  &.@{prefix}-size-s {
+    border-radius: @switch-shape-square-border-radius;
+  }
+
+  .@{prefix}-switch__handle {
+    border-radius: @switch-shape-square-border-radius;
+
+    &::before {
+      border-radius: @switch-shape-square-border-radius;
+    }
+  }
+}
+
+// shape: line - 线性外观（细轨道 + 圆形 handle 浮于轨道之上）
+.@{prefix}-switch--shape-line {
+  background-color: transparent;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: @switch-line-track-height-default;
+    border-radius: @border-radius-round;
+    background-color: @switch-unchecked-bg-color;
+    transform: translateY(-50%);
+    transition: @switch-transition;
+  }
+
+  &:hover {
+    background-color: transparent;
+
+    &::before {
+      background-color: @switch-unchecked-bg-color-hover;
+    }
+  }
+
+  &.@{prefix}-size-l::before {
+    height: @switch-line-track-height-l;
+  }
+
+  &.@{prefix}-size-s::before {
+    height: @switch-line-track-height-s;
+  }
+
+  &.@{prefix}-is-checked {
+    background-color: transparent;
+
+    &::before {
+      background-color: @switch-checked-bg-color;
+    }
+
+    &:hover {
+      background-color: transparent;
+
+      &::before {
+        background-color: @switch-checked-bg-color-hover;
+      }
+    }
+  }
+
+  &.@{prefix}-is-loading {
+    background-color: transparent;
+
+    &::before {
+      background-color: @switch-unchecked-bg-color-loading;
+    }
+
+    &.@{prefix}-is-checked::before {
+      background-color: @switch-checked-bg-color-loading;
+    }
+  }
+
+  &.@{prefix}-is-disabled {
+    background-color: transparent;
+
+    &::before {
+      background-color: @switch-unchecked-bg-color-disabled;
+    }
+
+    &.@{prefix}-is-checked::before {
+      background-color: @switch-checked-bg-color-disabled;
+    }
+  }
+}

--- a/style/web/components/switch/_var.less
+++ b/style/web/components/switch/_var.less
@@ -66,6 +66,14 @@
 @switch-content-margin-left-s: calc(@switch-min-width-s / 2 + 2px);
 @switch-content-margin-right-s: @comp-margin-xxs;
 
+// 形状 - square 圆角矩形
+@switch-shape-square-border-radius: @border-radius-medium;
+
+// 形状 - line 线性外观
+@switch-line-track-height-l: calc(@switch-height-l / 3);
+@switch-line-track-height-default: calc(@switch-height-default / 3);
+@switch-line-track-height-s: calc(@switch-height-s / 3);
+
 // 动画
 @switch-transition: all @anim-duration-base @anim-time-fn-easing;
 @switch-handle-transition: all @anim-duration-base @anim-time-fn-easing;


### PR DESCRIPTION
Add two new shape modifiers alongside the existing round appearance,
addressing #2563:

- `.t-switch--shape-square`: rounded-rectangle track and handle
- `.t-switch--shape-line`: thin track rendered via ::before, with the
  circular handle floating on top

Introduces `@switch-shape-square-border-radius` and
`@switch-line-track-height-{l,default,s}` tokens for downstream theming.

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- close Tencent/tdesign#2563 [Switch] 支持方形等外观设计

### 💡 需求背景和解决方案

**背景**

Switch 组件当前仅提供圆形（round）外观，样式过于单一，不便于设计和开发。Issue #2563 希望补齐 `square`（圆角矩形）与 `line`（线性）两种外观。

**方案**

在 `style/web/components/switch/` 下按 TDesign 一贯的 `--shape-xxx` 修饰符约定（参考 Button 组件）新增两个类，默认外观（不加 modifier）保持为 round