### PR TITLE
feat(checkbox): support button variant style

### DIFF
--- a/style/web/components/checkbox/_index.less
+++ b/style/web/components/checkbox/_index.less
@@ -19,6 +19,156 @@
   display: inline-flex;
   flex-wrap: wrap;
   gap: @checkbox-group-gap;
+
+  // button 风格：外边框
+  &.@{checkbox-cls}-group__outline {
+    flex-wrap: wrap;
+    row-gap: @checkbox-group-outline-gap;
+    column-gap: @checkbox-group-outline-gap;
+
+    &.@{prefix}-size-s .@{checkbox-button--cls} {
+      height: @checkbox-button-outline-height-small;
+    }
+
+    &.@{prefix}-size-m .@{checkbox-button--cls} {
+      height: @checkbox-button-outline-height-medium;
+    }
+
+    &.@{prefix}-size-l .@{checkbox-button--cls} {
+      height: @checkbox-button-outline-height-large;
+    }
+
+    .@{checkbox-button--cls} {
+      border-radius: @checkbox-button-border-radius;
+
+      &.@{prefix}-is-checked {
+        color: @checkbox-button-color-outline-checked;
+        border-color: @checkbox-button-border-color-checked;
+        background-color: @checkbox-button-background-color-outline-checked;
+      }
+
+      &.@{prefix}-is-disabled.@{prefix}-is-checked {
+        color: @brand-color-disabled;
+        border-color: @brand-color-disabled;
+        background-color: @checkbox-button-background-color-outline-disabled-checked;
+      }
+    }
+  }
+
+  // button 风格：默认色填充
+  &.@{checkbox-cls}-group--filled {
+    padding: @checkbox-group-filled-padding;
+    border-radius: @border-radius-default;
+    background-color: @checkbox-button-group-background-color-filled;
+    gap: 0;
+    column-gap: 2px;
+    row-gap: 2px;
+
+    .@{checkbox-button--cls} {
+      color: @checkbox-button-color-filled;
+      border: 0;
+      background-color: transparent;
+      border-radius: @checkbox-button-border-radius;
+
+      &:hover {
+        color: @checkbox-button-color-filled-hover;
+      }
+
+      &.@{prefix}-is-checked {
+        color: @checkbox-button-color-default-filled-checked;
+        background-color: @checkbox-button-background-color-default-filled-checked;
+      }
+
+      &.@{prefix}-is-disabled {
+        background-color: transparent;
+
+        &.@{prefix}-is-checked {
+          color: @checkbox-button-color-default-filled-disabled-checked;
+          background-color: @checkbox-button-background-color-default-filled-disabled-checked;
+        }
+      }
+    }
+  }
+
+  // button 风格：主色填充
+  &.@{checkbox-cls}-group--primary-filled {
+    .@{checkbox-button--cls} {
+      &.@{prefix}-is-checked {
+        color: @checkbox-button-color-primary-filled-checked;
+        background-color: @checkbox-button-background-color-primary-filled-checked;
+      }
+
+      &.@{prefix}-is-disabled.@{prefix}-is-checked {
+        color: @checkbox-button-color-primary-filled-checked;
+        background-color: @checkbox-button-background-color-primary-filled-disabled-checked;
+      }
+    }
+  }
+
+  // 纵向排列
+  &.@{checkbox-cls}-group--vertical {
+    flex-direction: column;
+    align-items: stretch;
+
+    .@{checkbox-button--cls} {
+      width: 100%;
+      justify-content: flex-start;
+    }
+  }
+
+  // 尺寸
+  &.@{prefix}-size-s .@{checkbox-button--cls} {
+    height: @checkbox-button-height-small;
+    padding: @checkbox-button-padding-small;
+    font: @checkbox-button-font-small;
+  }
+
+  &.@{prefix}-size-m .@{checkbox-button--cls} {
+    height: @checkbox-button-height-medium;
+    padding: @checkbox-button-padding-medium;
+    font: @checkbox-button-font-medium;
+  }
+
+  &.@{prefix}-size-l .@{checkbox-button--cls} {
+    height: @checkbox-button-height-large;
+    padding: @checkbox-button-padding-large;
+    font: @checkbox-button-font-large;
+  }
+
+  // 单个按钮
+  .@{checkbox-button--cls} {
+    cursor: pointer;
+    position: relative;
+    border: @checkbox-button-border;
+    border-color: @checkbox-button-border-color-default;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: @checkbox-button-transition;
+    color: @checkbox-label-color;
+    white-space: nowrap;
+    box-sizing: border-box;
+
+    &__former {
+      .input-visually-hidden();
+    }
+
+    &:hover {
+      color: @checkbox-button-color-outline-checked;
+      border-color: @checkbox-button-border-color-checked;
+    }
+
+    &.@{prefix}-is-disabled {
+      cursor: not-allowed;
+      color: @checkbox-button-color-disabled;
+      background-color: @checkbox-button-background-color-disabled;
+
+      &:hover {
+        color: @checkbox-button-color-disabled;
+        border-color: @checkbox-button-border-color-default;
+      }
+    }
+  }
 }
 
 .@{checkbox-cls} {

--- a/style/web/components/checkbox/_var.less
+++ b/style/web/components/checkbox/_var.less
@@ -12,6 +12,7 @@
 // 如：@button-line-height-s
 
 @checkbox-cls: ~'@{prefix}-checkbox';
+@checkbox-button--cls: ~'@{prefix}-checkbox-button';
 
 // 颜色
 @checkbox-border-color: @border-level-2-color;
@@ -32,6 +33,27 @@
 
 @checkbox-label-color: @text-color-primary;
 
+// button 风格颜色
+@checkbox-button-border-color-default: @border-level-2-color;
+@checkbox-button-border-color-checked: @brand-color;
+@checkbox-button-color-outline-checked: @brand-color;
+@checkbox-button-background-color-outline-checked: @bg-color-container-select;
+@checkbox-button-background-color-disabled: @bg-color-component-disabled;
+@checkbox-button-color-disabled: @text-color-disabled;
+@checkbox-button-background-color-outline-disabled-checked: @bg-color-specialcomponent;
+@checkbox-button-color-disabled-checked: @text-color-disabled;
+
+@checkbox-button-group-background-color-filled: @bg-color-component;
+@checkbox-button-color-filled: @text-color-secondary;
+@checkbox-button-color-filled-hover: @text-color-primary;
+@checkbox-button-color-default-filled-checked: @text-color-primary;
+@checkbox-button-color-primary-filled-checked: @text-color-anti;
+@checkbox-button-color-default-filled-disabled-checked: @text-color-disabled;
+@checkbox-button-background-color-default-filled-checked: @bg-color-container;
+@checkbox-button-background-color-primary-filled-checked: @brand-color;
+@checkbox-button-background-color-default-filled-disabled-checked: @bg-color-component-disabled;
+@checkbox-button-background-color-primary-filled-disabled-checked: @brand-color-disabled;
+
 // 尺寸
 @checkbox-size: 16px;
 @checkbox-border-radius: @border-radius-default;
@@ -46,11 +68,33 @@
 @checkbox-indeterminate-height: 4px;
 @checkbox-indeterminate-color: @font-white-1;
 
+// button 尺寸
+@checkbox-button-border-radius: @border-radius-small;
+@checkbox-button-outline-height-small: @comp-size-xs;
+@checkbox-button-outline-height-medium: @comp-size-m;
+@checkbox-button-outline-height-large: @comp-size-xl;
+@checkbox-button-height-small: calc(@comp-size-xs - (@comp-paddingTB-xxs * 2));
+@checkbox-button-height-medium: calc(@comp-size-m - (@comp-paddingTB-xxs * 2));
+@checkbox-button-height-large: calc(@comp-size-xl - (@comp-paddingTB-xxs * 2));
+
 // 字号
 @checkbox-font: @font-body-medium;
+@checkbox-button-font-small: @font-body-small;
+@checkbox-button-font-medium: @font-body-medium;
+@checkbox-button-font-large: @font-body-large;
 
 // padding
 @checkbox-input-label-spacer: @spacer;
+@checkbox-button-padding-small: 0px @comp-paddingLR-s;
+@checkbox-button-padding-medium: @comp-paddingTB-xs @comp-paddingLR-l;
+@checkbox-button-padding-large: @comp-paddingTB-s @comp-paddingLR-xl;
+@checkbox-button-border: 1px solid;
+
+@checkbox-group-outline-gap: @comp-margin-xs;
+@checkbox-group-filled-padding: @comp-paddingTB-xxs @comp-paddingLR-xxs;
+
+// 动画&过度
+@checkbox-button-transition: color @anim-duration-base @anim-time-fn-ease-out, background-color @anim-duration-base @anim-time-fn-ease-out, border-color @anim-duration-base @anim-time-fn-ease-out;
 
 // 组合复选框margin
 @checkbox-group-gap: @spacer-2;


### PR DESCRIPTION
Add outline / filled / primary-filled button variants for CheckboxGroup,
with size (s|m|l) and vertical layout support. Introduces
`t-checkbox-button` element class and companion variables in _var.less.

close #2562

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

close #2562

### 💡 需求背景和解决方案

**背景**：在 CRM / OA 等后台管理系统中，管理员常需要一次性勾选十几个权限项。传统 Checkbox 列表存在几个痛点：
1. 权限项多时（10+），传统多选框列表冗长，用户需逐行核对"勾"的状态，容易漏看或误判；
2. 频繁点击小方框易产生疲劳感；
3. "勾"的视觉对比弱，无法满足后台系统"清晰可控、操作结果明确"的诉求。

**方案**：对齐 `RadioGroup` 已有的 button 风格能力，为 `CheckboxGroup` 新增按钮风格变体。选中项通过深色描边 / 深色填充突出，未选中项为浅色描边或透明背景，用户能快速定位已选中的权限。

**样式实现（本 PR 范围）**：
在 `style/web/components/checkbox/` 下扩展样式：

- `_var.less` 新增 `@checkbox-button--cls` 元素类、以及 outline / filled / primary-filled 三种风格的颜色、尺寸、字号、padding、动画变量；
- `_index.less` 在 `.t-checkbox-group` 上新增以下修饰类：
  - `.t-checkbox-group__outline`：外描边风格，选中态品牌色描边 + 浅色底；
  - `.t-checkbox-group--filled`：默认色填充风格，group 带浅灰底，选中项为白色高亮块；
  - `.t-checkbox-group--primary-filled`：主色填充风格，选中态品牌色底 + 反色文字；
  - `.t-checkbox-group--vertical`：纵向排列，按钮撑满宽度；
  - 三档 size（s / m / l）适配高度、字号、内边距；
  - hover / checked / disabled 三态齐全。

**框架侧接入**：本 PR 仅完成公共样式层。tdesign-vue-next / tdesign-react 侧 `CheckboxGroup` 后续可通过新增 `variant` prop 透出上述 class 完成对接，逻辑类比现有 `RadioGroup` 的 button 变体，无需 breaking change。

### 📝 更新日志

- feat(checkbox): CheckboxGroup 支持 button 风格（outline / filled / primary-filled），并支持三档尺寸与纵向排列

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充（本 PR 只涉及公共样式层，框架侧接入后再更新对应文档）
- [x] 代码演示已提供或无须提供（同上）
- [x] TypeScript 定义已补充或无须补充（本 PR 无 TS 改动）
- [x] Changelog 已提供或无须提供