### PR TITLE
feat(ColorPicker): support input-less trigger style

### DIFF
--- a/style/web/components/color-picker/_index.less
+++ b/style/web/components/color-picker/_index.less
@@ -521,6 +521,20 @@
       padding: @color-picker-trigger-input-padding;
     }
 
+    &--no-input {
+      .@{prefix}-input--auto-width {
+        min-width: @comp-size-xl;
+      }
+
+      .@{prefix}-input__prefix {
+        margin-right: 0;
+      }
+
+      .@{prefix}-input__inner {
+        display: none;
+      }
+    }
+
     &__color {
       width: 100%;
       height: 100%;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2567
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

支持无文字输入框样式
在本仓库增加了colorpicker触发器的no-input样式
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
### 其他相关pr
新增api：https://github.com/TDesignOteam/tdesign-api/pull/911
添加no-input class并实现透传：https://github.com/Tencent/tdesign-react/pull/4306

已在本地联调，ui效果如图：
设置`<ColorPicker defaultValue="#0052d9" isInput={false} />`可实现如图效果
<img width="467" height="166" alt="ca521cf050a4281f898fc67067c6d28f" src="https://github.com/user-attachments/assets/6be04568-3c12-474b-beb3-994559f946b5" />

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(ColorPicker): support input-less trigger style

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
