### PR TITLE
feat(textarea): add clearable styles and docs

### DIFF
--- a/docs/web/api/textarea.en-US.md
+++ b/docs/web/api/textarea.en-US.md
@@ -18,6 +18,12 @@ Limits the maximum number of characters entered and displays the number of chara
 
 {{ maxlength }}
 
+### Clearable Textarea
+
+A multiline text box with a clear operation, which can quickly clear entered content.
+
+{{ clearable }}
+
 ### Binding DOM Events
 
 You can bind DOM native events such as `onKeypress` `onKeydown` `onKeyup` `onFocus` `onBlur`.

--- a/docs/web/api/textarea.md
+++ b/docs/web/api/textarea.md
@@ -18,6 +18,12 @@ spline: form
 
 {{ maxlength }}
 
+### 可清空的多行文本框
+
+带清空操作的多行文本框，可快捷清空输入过的内容。
+
+{{ clearable }}
+
 ### 绑定 DOM 事件
 
 可绑定 `onKeypress` `onKeydown` `onKeyup` `onFocus` `onBlur` 等 DOM 原生事件。

--- a/style/web/components/textarea/_index.less
+++ b/style/web/components/textarea/_index.less
@@ -67,6 +67,27 @@
     color: @textarea-limit-color;
   }
 
+  &__clear {
+    position: absolute;
+    top: @comp-paddingLR-s;
+    right: @comp-paddingLR-s;
+    z-index: 1;
+    cursor: pointer;
+    color: @textarea-limit-color;
+    opacity: 0;
+    visibility: hidden;
+    transition: @anim-duration-base linear;
+
+    &:hover {
+      color: @text-color-secondary;
+    }
+  }
+
+  &.@{prefix}-textarea--clearable:hover &__clear {
+    opacity: 1;
+    visibility: visible;
+  }
+
   .@{prefix}-is-disabled {
     color: @textarea-color-text-disabled;
     background-color: @textarea-bg-color-disabled;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

Closes https://github.com/Tencent/tdesign-common/issues/2566

关联框架实现 PR:

- https://github.com/Tencent/tdesign-react/pull/4319
 
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

Textarea 缺少与 Input 一致的可清空能力。用户在输入多行文本后，需要通过手动选删除内容完成清空。

Textarea 组件新增 `clearable` 能力后，需要在 common 中补充跨框架共享样式和文档说明。

实现内容：
1. 新增 `.t-textarea__clear` 清空图标样式
2. 新增 `.t-textarea--clearable:hover .t-textarea__clear` hover 可见规则
3. 清空图标定位在 textarea 右上角，避免影响右下角原生 resize 拖拽区域
4. 在中英文 textarea common 文档中新增 clearable 示例占位

验证：

- `npx lessc style/web/components/textarea/_index.less /tmp/textarea-out.css`

效果展示：

> react


https://github.com/user-attachments/assets/787e7f38-1c71-4fb6-9547-1bcb82e0198e

  
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(textarea): 支持多行文本框清空图标样式与文档说明

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供