### PR TITLE
fix(calcTextareaHeight): fix multiple textareas calcTextareaHeight 

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
-        with:
-          version: 9
       - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version

--- a/js/utils/calcTextareaHeight.ts
+++ b/js/utils/calcTextareaHeight.ts
@@ -20,58 +20,55 @@ const TEXTAREA_STYLE = `
   right:0 !important
 `;
 
-let hiddenTextarea: HTMLTextAreaElement;
-
 function calcTextareaHeight(
   targetElement: HTMLTextAreaElement,
   minRows: LimitType = 1,
   maxRows: LimitType = null
 ): CalculateStyleType {
-  if (!hiddenTextarea) {
-    hiddenTextarea = document.createElement('textarea');
-    document.body.appendChild(hiddenTextarea);
-  }
+  const hiddenTextarea = document.createElement('textarea');
+  document.body.appendChild(hiddenTextarea);
 
-  const { paddingSize, borderSize, boxSizing, sizingStyle } = calculateNodeSize(targetElement);
+  try {
+    const { paddingSize, borderSize, boxSizing, sizingStyle } = calculateNodeSize(targetElement);
 
-  hiddenTextarea.setAttribute('style', `${sizingStyle};${TEXTAREA_STYLE}`);
-  hiddenTextarea.value = targetElement.value || targetElement.placeholder || '';
+    hiddenTextarea.setAttribute('style', `${sizingStyle};${TEXTAREA_STYLE}`);
+    hiddenTextarea.value = targetElement.value || targetElement.placeholder || '';
 
-  let height = hiddenTextarea.scrollHeight;
-  const result: CalculateStyleType = {};
-  const isBorderbox = boxSizing === 'border-box';
-  const isContentbox = boxSizing === 'content-box';
+    let height = hiddenTextarea.scrollHeight;
+    const result: CalculateStyleType = {};
+    const isBorderbox = boxSizing === 'border-box';
+    const isContentbox = boxSizing === 'content-box';
 
-  if (isBorderbox) {
-    height += borderSize;
-  } else if (isContentbox) {
-    height -= paddingSize;
-  }
-
-  hiddenTextarea.value = '';
-  const singleRowHeight = hiddenTextarea.scrollHeight - paddingSize;
-  hiddenTextarea?.parentNode?.removeChild(hiddenTextarea);
-  // @ts-ignore
-  hiddenTextarea = null;
-
-  const calcHeight = (rows: number) => {
-    let rowsHeight = singleRowHeight * rows;
     if (isBorderbox) {
-      rowsHeight = rowsHeight + paddingSize + borderSize;
+      height += borderSize;
+    } else if (isContentbox) {
+      height -= paddingSize;
     }
-    return rowsHeight;
-  };
 
-  if (!isNull(minRows)) {
-    const minHeight = calcHeight(minRows);
-    height = Math.max(minHeight, height);
-    result.minHeight = `${minHeight}px`;
+    hiddenTextarea.value = '';
+    const singleRowHeight = hiddenTextarea.scrollHeight - paddingSize;
+
+    const calcHeight = (rows: number) => {
+      let rowsHeight = singleRowHeight * rows;
+      if (isBorderbox) {
+        rowsHeight = rowsHeight + paddingSize + borderSize;
+      }
+      return rowsHeight;
+    };
+
+    if (!isNull(minRows)) {
+      const minHeight = calcHeight(minRows);
+      height = Math.max(minHeight, height);
+      result.minHeight = `${minHeight}px`;
+    }
+    if (!isNull(maxRows)) {
+      height = Math.min(calcHeight(maxRows), height);
+    }
+    result.height = `${height}px`;
+    return result;
+  } finally {
+    hiddenTextarea.parentNode?.removeChild(hiddenTextarea);
   }
-  if (!isNull(maxRows)) {
-    height = Math.min(calcHeight(maxRows), height);
-  }
-  result.height = `${height}px`;
-  return result;
 }
 
 export default calcTextareaHeight;

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-prettier": "^5.2.1",
     "husky": "^8.0.1",
+    "jsdom": "catalog:",
     "lint-staged": "~13.2.0",
     "min-indent": "^1.0.1",
     "postcss-less": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-prettier": "^5.2.1",
     "husky": "^8.0.1",
-    "jsdom": "catalog:",
+    "jsdom": "^29.1.1",
     "lint-staged": "~13.2.0",
     "min-indent": "^1.0.1",
     "postcss-less": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "homepage": "https://github.com/Tencent",
   "description": "TDesign UI 样式库以及组件库公共函数（js）",
+  "packageManager": "pnpm@10.27.0",
   "main": "",
   "scripts": {
     "lint": "npm run lint:css && npm run lint:js && npm run lint:eslint && npm run typecheck",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+catalog:
+  jsdom: ^29.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,1 @@
-catalog:
-  jsdom: ^29.1.1
+catalogMode: manual

--- a/test/unit/utils/calcTextareaHeight.test.ts
+++ b/test/unit/utils/calcTextareaHeight.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import calcTextareaHeight from '../../../js/utils/calcTextareaHeight';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('calcTextareaHeight', () => {
+  it('removes hidden textarea after height calculation', () => {
+    const textarea = document.createElement('textarea');
+    textarea.value = 'textarea content';
+    document.body.appendChild(textarea);
+
+    const result = calcTextareaHeight(textarea);
+
+    expect(result.height).toBeDefined();
+    expect(document.body.querySelectorAll('textarea')).toHaveLength(1);
+  });
+
+  it('removes hidden textarea after reentrant height calculations', () => {
+    const firstTextarea = document.createElement('textarea');
+    firstTextarea.value = 'first textarea content';
+    document.body.appendChild(firstTextarea);
+
+    const secondTextarea = document.createElement('textarea');
+    secondTextarea.value = 'second textarea content';
+    document.body.appendChild(secondTextarea);
+
+    let isReentered = false;
+    vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockImplementation(function mockScrollHeight() {
+      if (!isReentered && !this.isConnected) return 0;
+      if (!isReentered && this !== firstTextarea && this !== secondTextarea) {
+        isReentered = true;
+        calcTextareaHeight(secondTextarea);
+      }
+      return 20;
+    });
+
+    const result = calcTextareaHeight(firstTextarea);
+
+    expect(result.height).toBeDefined();
+    expect(document.body.querySelectorAll('textarea')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/6681
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
- calcTextareaHeight 使用了模块级共享变量 hiddenTextarea，所有 t-textarea 实例共用同一个隐藏 textarea。
- autosize 会在 onMounted、watch(innerValue)、watch(refTextareaElem) 等多个时机通过 nextTick 触发高度计算。
- 多个 textarea 同时渲染或计算重入时，一个实例可能还在使用隐藏节点，另一个实例已经复用并移除了它。
- 旧清理逻辑依赖共享状态，且没有 finally 兜底；一旦计算过程被打断或交错，隐藏 textarea 可能残留在 document.body。
- 根因不是组件模板多渲染了 textarea，而是 autosize 高度测量工具的共享临时 DOM 节点存在竞态/重入风险。
修复方向：每次 calcTextareaHeight 调用都创建本地隐藏 textarea，计算结束后在 finally 中清理，避免跨实例共享。
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
