### PR TITLE
fix(descriptions): 修复布局美感太差问题

### DIFF
--- a/style/web/components/descriptions/_index.less
+++ b/style/web/components/descriptions/_index.less
@@ -59,7 +59,11 @@
 
     :not(&--fixed):not(&--border) {
       @{root}__label {
-        padding-right: @comp-paddingLR-l;
+        &::after {
+          content: ':';
+          display: inline-block;
+          margin-left: @comp-margin-s;
+        }
       }
     }
   }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 组件样式

### 🔗 相关 Issue

[https://github.com/Tencent/tdesign-common/issues/2431](2431)

### 💡 需求背景和解决方案
问题：需要同时完成 基础示例的UI 设计和任意一侧的组件代码，增强美观
方案：只需改样式，使用: :after伪元素，添加冒号和margin增强美观
样式更改如下：
<img width="1266" height="1242" alt="3444608b9b2548fa8bccb733f8d42261" src="https://github.com/user-attachments/assets/bd65d95c-d60f-41a6-9901-31e6bf448871" />

> 

-->

### 📝 其他方案

> 我发现这样仅仅修改样式，pr提到的基础示例成功显示，但标签引号示例因为项目默认勾选标签引号，而且标签引号是无边框模式，所以会同时出现两个冒号。如图，
<img width="1218" height="675" alt="ef2faf61b5206cc0fa55e5fde41a26f8" src="https://github.com/user-attachments/assets/afc23b89-df70-425a-959d-a8fad38e3d58" />

，我找到另个简单的解决方案  ，已经提[ p r ](https://github.com/Tencent/tdesign-vue-next/pull/6787)
有什么其他问题可以随时艾特我