### PR TITLE
fix(color-picker): prevent gradient degree input overflow

### DIFF
--- a/style/web/components/color-picker/_index.less
+++ b/style/web/components/color-picker/_index.less
@@ -245,7 +245,8 @@
   margin-bottom: @color-picker-margin;
 
   &-slider {
-    flex: 1;
+    flex: 1 1 0;
+    min-width: 0;
   }
 
   &-degree {
@@ -257,9 +258,11 @@
       margin: 0;
       font: @color-picker-font;
     }
-    .@{prefix}-input-number {
+    .@{prefix}-input-number,
+    .@{prefix}-input-number.@{prefix}-size-s {
       width: 100%;
       padding: 0;
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

Related Tencent/tdesign-react#4323

### 💡 需求背景和解决方案

修复 ColorPicker 面板在渐变模式下，角度输入框超出面板边界的问题。

本次调整仅修改 ColorPicker 的公共样式：

- 允许渐变 slider 在 flex 布局中正常收缩
- 覆盖渐变角度区域内 `InputNumber size="small"` 的默认宽度，避免撑开面板
- 不修改 DOM 结构、组件 API 或交互逻辑
- 不新增依赖

### 📝 更新日志

- fix(ColorPicker): 修复渐变模式下角度输入框溢出面板的问题

### ☑️ 自测情况

<img width="2850" height="1390" alt="image" src="https://github.com/user-attachments/assets/748baa37-abbc-4c3e-b9d2-8a5307ace2b6" />
<img width="2850" height="1390" alt="image" src="https://github.com/user-attachments/assets/d570b2b7-790b-439d-9efe-aa48e354e2e6" />
<img width="2850" height="1390" alt="image" src="https://github.com/user-attachments/assets/8ed2138f-26a4-41b3-ae52-a9d8b7a4659a" />
<img width="2850" height="1390" alt="image" src="https://github.com/user-attachments/assets/9e047f68-4880-4178-a17d-a12b65fda95c" />
<img width="2850" height="1390" alt="image" src="https://github.com/user-attachments/assets/0642db57-7d84-4d41-a84a-9f5997e126f8" />


- [x] `git diff --check`
- [x] `stylelint style/web/components/color-picker/_index.less`
- [x] 本地启动 tdesign-react 站点验证 ColorPicker “面板颜色选择器”示例
- [x] 验证切换到“渐变”模式后，角度输入框不再溢出面板
- [x] 验证切回“单色”模式后原有布局正常