### PR TITLE
feat(ColorPicker): add color dropper support

### DIFF
--- a/js/color-picker/dropper.ts
+++ b/js/color-picker/dropper.ts
@@ -1,0 +1,35 @@
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper/open#options
+ */
+export interface EyeDropperOpenOptions {
+  signal?: AbortSignal
+}
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper_API
+ */
+export interface EyeDropper {
+  new(): EyeDropper
+  open: (options?: EyeDropperOpenOptions) => Promise<{ sRGBHex: string }>
+  [Symbol.toStringTag]: 'EyeDropper'
+}
+
+/** 取色器 */
+export function useDropper() {
+  const support = typeof window !== 'undefined' && 'EyeDropper' in window
+  async function open(options?: EyeDropperOpenOptions) {
+    if(!support) {
+      return
+    }
+
+    const eyeDropper: EyeDropper = new (window as any).EyeDropper()
+    const result = await eyeDropper.open(options)
+    return result
+  }
+
+
+  return {
+    support,
+    open,
+  }
+}

--- a/js/color-picker/index.ts
+++ b/js/color-picker/index.ts
@@ -2,6 +2,7 @@ export * from './cmyk';
 export * from './color';
 export * from './constants';
 export * from './draggable';
+export * from './dropper'
 export * from './format';
 export * from './gradient';
 export * from './types';

--- a/style/web/components/color-picker/_index.less
+++ b/style/web/components/color-picker/_index.less
@@ -238,6 +238,11 @@
   }
 }
 
+
+.@{prefix}-color-picker__dropper {
+  margin-left: @color-picker-margin;
+}
+
 .@{prefix}-color-picker__gradient {
   padding: 0;
   display: flex;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
resolves #2568
Reference PR: [#6811](http://github.com/Tencent/tdesign-vue-next/pull/6811)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

使用浏览器原生 [EyeDropper API](https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper_API) 实现屏幕取色功能
在 tdesign-vue-next 上实现相关逻辑。
若浏览器不支持该API则自动隐藏此按钮

<img width="400" alt="image" src="https://github.com/user-attachments/assets/a9e0772f-7033-4986-84e7-8bd335186be8" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/04dcf4b2-6b8e-4d27-8d38-bdae1d086d41" />



### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(ColorPicker): add color dropper support

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
