### PR TITLE
fix(Button): 修复自定义 SVG 图标与文字的间距

### DIFF
--- a/style/web/components/button/_index.less
+++ b/style/web/components/button/_index.less
@@ -64,7 +64,8 @@
     font-size: @btn-loading-size;
   }
 
-  .t-icon + .@{prefix}-button__text:not(:empty) {
+  .t-icon + .@{prefix}-button__text:not(:empty),
+  svg + .@{prefix}-button__text:not(:empty) {
     margin-left: @btn-icon-text-margin-left;
   }
 

--- a/style/web/components/button/_index.less
+++ b/style/web/components/button/_index.less
@@ -64,7 +64,6 @@
     font-size: @btn-loading-size;
   }
 
-  .t-icon + .@{prefix}-button__text:not(:empty),
   svg + .@{prefix}-button__text:not(:empty) {
     margin-left: @btn-icon-text-margin-left;
   }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Closes #2559

### 💡 需求背景和解决方案

当 Button 的图标插槽传入没有 `t-icon` 类名的普通 SVG 时，现有选择器不会为后续文字添加间距，导致图标和文字紧贴。

为普通 SVG 与非空 Button 文本添加与 `t-icon` 相同的相邻兄弟选择器，使自定义 SVG 图标保持既有的图标文字间距。

### 📝 更新日志

- fix(Button): 修复自定义 SVG 图标与文字之间缺少间距的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 验证

- [x] `pnpm run test`（28 个测试文件，548 个测试通过）
- [x] 提交钩子中的 `stylelint --fix --allow-empty-input`
- [ ] `pnpm run lint`：受该文件 4 处既有多行 `:not()` 选择器的 Stylelint 缩进规则阻断；本 PR 未修改这些既有行。