### PR TITLE
feat(Switch): 支持圆角和线性形态

### DIFF
--- a/docs/web/api/switch.en-US.md
+++ b/docs/web/api/switch.en-US.md
@@ -29,3 +29,9 @@ Switches for normal, loading and disabled are provided. Set the corresponding st
 Large, medium (default) and small switches are provided.
 
 {{ size }}
+
+### Switches of Different Shapes
+
+Circle, round and line shapes are provided. Circle is the default pill shape, round uses a rounded rectangle, and line does not render switch content.
+
+{{ shape }}

--- a/docs/web/api/switch.md
+++ b/docs/web/api/switch.md
@@ -29,3 +29,9 @@ spline: form
 提供 大、中（默认）、小 3种开关。
 
 {{ size }}
+
+### 不同形状的开关
+
+提供 circle、round 和 line 3 种形状。circle 为默认胶囊形态，round 为圆角矩形形态，line 为线性形态且不展示开关描述。
+
+{{ shape }}

--- a/style/web/components/switch/_index.less
+++ b/style/web/components/switch/_index.less
@@ -271,3 +271,124 @@
     }
   }
 }
+
+.@{prefix}-switch {
+  &.@{prefix}-switch--shape-round {
+    border-radius: @switch-round-track-border-radius;
+
+    .@{prefix}-switch__handle,
+    .@{prefix}-switch__handle::before {
+      border-radius: @switch-round-handle-border-radius;
+    }
+  }
+
+  &.@{prefix}-switch--shape-line {
+    background-color: transparent;
+    overflow: visible;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 0;
+      right: 0;
+      height: @switch-line-track-height-default;
+      border-radius: @border-radius-round;
+      background-color: @switch-unchecked-bg-color;
+      transform: translateY(-50%);
+      transition: @switch-transition;
+    }
+
+    &:hover {
+      background-color: transparent;
+
+      &::before {
+        background-color: @switch-unchecked-bg-color-hover;
+      }
+    }
+
+    .@{prefix}-switch__handle {
+      z-index: 1;
+      top: 50%;
+      left: 0;
+      width: calc(@switch-height-default - 2 * @switch-width-border-check-default);
+      height: calc(@switch-height-default - 2 * @switch-width-border-check-default);
+      transform: translateY(-50%);
+    }
+
+    .@{prefix}-switch__content {
+      position: relative;
+      z-index: 1;
+    }
+
+    &:active:not(.@{prefix}-is-disabled):not(.@{prefix}-is-loading) {
+      .@{prefix}-switch__handle::before {
+        left: 0;
+        right: 0;
+      }
+    }
+
+    &.@{prefix}-is-checked {
+      background-color: transparent;
+
+      &::before {
+        background-color: @switch-checked-bg-color;
+      }
+
+      &:hover::before {
+        background-color: @switch-checked-bg-color-hover;
+      }
+
+      .@{prefix}-switch__handle {
+        left: 100%;
+        transform: translate(-100%, -50%);
+      }
+    }
+
+    &.@{prefix}-is-loading {
+      background-color: transparent;
+
+      &::before {
+        background-color: @switch-unchecked-bg-color-loading;
+      }
+
+      &.@{prefix}-is-checked::before {
+        background-color: @switch-checked-bg-color-loading;
+      }
+    }
+
+    &.@{prefix}-is-disabled {
+      background-color: transparent;
+
+      &::before {
+        background-color: @switch-unchecked-bg-color-disabled;
+      }
+
+      &.@{prefix}-is-checked::before {
+        background-color: @switch-checked-bg-color-disabled;
+      }
+    }
+  }
+}
+
+.@{prefix}-switch.@{prefix}-size-l.@{prefix}-switch--shape-line {
+  &::before {
+    height: @switch-line-track-height-l;
+  }
+
+  .@{prefix}-switch__handle {
+    width: calc(@switch-height-l - 2 * @switch-width-border-check-l);
+    height: calc(@switch-height-l - 2 * @switch-width-border-check-l);
+  }
+}
+
+.@{prefix}-switch.@{prefix}-size-s.@{prefix}-switch--shape-line {
+  &::before {
+    height: @switch-line-track-height-s;
+  }
+
+  .@{prefix}-switch__handle {
+    width: calc(@switch-height-s - 2 * @switch-width-border-check-s);
+    height: calc(@switch-height-s - 2 * @switch-width-border-check-s);
+  }
+}

--- a/style/web/components/switch/_var.less
+++ b/style/web/components/switch/_var.less
@@ -51,6 +51,13 @@
 @switch-width-border-check-default: (@switch-width-border-check-base - @switch-width-border-check-value * 1);
 @switch-width-border-check-s: (@switch-width-border-check-base - @switch-width-border-check-value * 2);
 
+// shape
+@switch-round-track-border-radius: @border-radius-default;
+@switch-round-handle-border-radius: @border-radius-small;
+@switch-line-track-height-l: 4px;
+@switch-line-track-height-default: 4px;
+@switch-line-track-height-s: 3px;
+
 // 字体
 @switch-content-font-size-l: @font-size-l;
 @switch-content-font-size-default: @font-size-s;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Closes #2563

### 💡 需求背景和解决方案

为 Web Switch 的 `shape` API 提供公共样式实现：

- `circle` 保持现有默认胶囊样式不变；
- `round` 采用圆角矩形轨道和 handle；
- `line` 使用独立细轨道，保持 handle 的三种尺寸、hover、选中、loading、disabled 和按压状态。

样式复用现有 Switch 的语义色和动画 token，不改变既有组件结构、焦点或键盘交互。`line` 形态下 label 由各框架的 `shape` API 实现负责不渲染；文档中已明确说明。

### 🆚 方案对比

| 对比维度 | 本方案 | 取舍与收益 |
| --- | --- | --- |
| 线性形态占位 | 保持原有 Switch 的宽度和最小交互区域，仅将背景替换为细轨道 | 不会因为切换 `shape` 改变表单布局或缩小可点击区域 |
| 尺寸适配 | handle 尺寸由既有的高度和边框 token 推导，轨道仅按 `l/default/s` 调整高度 | 下游自定义已有尺寸 token 后，线性形态可同步适配，不需要维护另一组固定宽度和 handle 尺寸 |
| 按压反馈 | 显式重置默认胶囊形态在按压时的 handle 拉伸 | 线性轨道下 handle 仍保持圆形，避免压住轨道或产生视觉跳变 |
| 状态层级 | 轨道分别使用既有的 unchecked、checked、loading、disabled 语义色，并让 handle 位于轨道之上 | 亮色与暗色主题均沿用组件现有状态 token，保持状态可辨识性 |
| 语义边界 | 公共样式只处理视觉；`line` 的 label 由框架 API 层直接不渲染 | 避免用 CSS 隐藏业务内容，DOM 和辅助技术语义与 API 约定一致 |

本方案的重点不是额外引入一套独立控件尺寸，而是在保持现有 Switch 布局和交互边界的前提下完成外观分层，降低各框架接入和后续主题定制的成本。


### 与现有方案的具体对比

已对照以下候选 PR 的实现 diff：[#2604](https://github.com/Tencent/tdesign-common/pull/2604)、[#2606](https://github.com/Tencent/tdesign-common/pull/2606)、[#2611](https://github.com/Tencent/tdesign-common/pull/2611)。

| 候选方案 | 实现特点 | 本方案的差异 |
| --- | --- | --- |
| #2604 | 为 `line` 单独定义固定宽度（`39/32/26px`）和一组 handle 尺寸 | 保留原 Switch 的宽度与最小交互区域；handle 从已有高度和边框 token 推导，避免切换 shape 改变表单布局，也减少独立尺寸 token 的维护 |
| #2611 | 已处理 round/line 和尺寸轨道，但 line 没有覆盖默认 Switch 的按压 handle 拉伸 | 额外重置 line 形态的按压拉伸，确保按压过程中 handle 仍为圆形且不会遮挡细轨道 |
| #2606 | 同时尝试 Web 和移动端实现；Web 线性轨道没有按 `l/default/s` 单独设置厚度 | 本 PR 只对接已确认的 Web `shape` 类名契约，并针对三种 Web 尺寸分别设置轨道厚度和 handle 尺寸；移动端等待对应 API 契约明确后独立接入 |

共同部分均采用现有 Switch 的 checked、unchecked、loading、disabled 语义色。本方案的重点是保持既有布局边界和按压反馈，同时让下游主题定制继续复用现有尺寸 token。
### 📝 更新日志

- feat(Switch): 支持 round 和 line 两种 shape 外观

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须提供
- [x] Changelog 已提供或无须提供

### 验证

- [x] `pnpm run test`（28 个测试文件，548 个测试通过）
- [x] `pnpm run typecheck`
- [x] `pnpm exec stylelint style/web/components/switch/_index.less style/web/components/switch/_var.less --allow-empty-input`
- [x] `pnpm exec prettier --check docs/web/api/switch.md docs/web/api/switch.en-US.md`
- [ ] `pnpm run lint`：仓库基线有 738 个既有文件不符合当前 Prettier 规则；新增文档与 Switch 样式的针对性检查均通过。