### PR TITLE
fix（descriptions）：修复布局美感太差问题--ttr

### DIFF
--- a/style/web/components/descriptions/_index.less
+++ b/style/web/components/descriptions/_index.less
@@ -57,9 +57,17 @@
       }
     }
 
-    :not(&--fixed):not(&--border) {
-      @{root}__label {
-        padding-right: @comp-paddingLR-l;
+    :not(&&--fited):not(&&-borded) {
+      @{root}_label {
+        // 1. 保留适当的右侧间距
+        padding-right: @comp-paddingLR-1;
+
+        &:not(.t-descriptions__label--colon)::after {
+          content: ':';
+          margin-left: 2px;
+          margin-right: 6px;  // 冒号和内容之间的间距
+          color: inherit;
+        }
       }
     }
   }


### PR DESCRIPTION
Updated styles for descriptions component to adjust padding and add colon after labels.

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ✔] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-common/issues/2431%5D(https://github.com/Tencent/tdesign-common/pull/2431

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题：需要同时完成 基础示例的UI 设计和任意一侧的组件代码，增强美观
方案：只需改样式，使用： ：after伪元素，添加冒号和margin增强美观
在 `_index.less` 中为 `.t-descriptions__label` 添加 `::after` 伪元素，在无边框模式下显示冒号（`:`），并调整 `margin-left` 和 `margin-right` 控制间距。同时通过 `:not(.t-descriptions__label--colon)` 选择器避免与 `colon` 属性冲突，确保启用"标签引号"时不会出现重复冒号。

改动文件：style/web/components/descriptions/_index.less

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
从用户视角来看，本次变更使得 Descriptions 组件在无边框（bordered: false）模式下，标签（Label）后面自动显示一个美观的冒号，并优化了标签与内容之间的间距，整体排版更清晰、更接近主流组件库的视觉体验。该改动仅涉及样式层面的增强，不改变任何组件 API 或现有使用方式，因此不存在破坏性变更（Breaking Change），也不会影响已有业务逻辑，升级后原有代码无需任何修改即可获得更好的显示效果。

- fix(组件名称): 处理问题或特性描述 ...
- fix（descriptions）：修复布局美感太差问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
