### PR TITLE
feat(color-picker): add native EyeDropper API support

### DIFF
--- a/js/color-picker/eyedropper.ts
+++ b/js/color-picker/eyedropper.ts
@@ -1,0 +1,30 @@
+import { EyeDropperOpenOptions } from './types';
+
+/**
+ * @see https://developer.mozilla.org/zh-CN/docs/Web/API/EyeDropper
+ * PR合并后 该文件可以删除
+ * */
+export const getEyeDropper = () => {
+  if (typeof window === 'undefined') return undefined;
+
+  const EyeDropperClass = window.EyeDropper;
+  if (EyeDropperClass === undefined) {
+    // 浏览器不支持 EyeDropper 兼容性:https://developer.mozilla.org/zh-CN/docs/Web/API/EyeDropper#%E6%B5%8F%E8%A7%88%E5%99%A8%E5%85%BC%E5%AE%B9%E6%80%A7
+    return undefined;
+  }
+
+  const eyeDropper = new EyeDropperClass();
+  const originOpen = eyeDropper.open.bind(eyeDropper);
+  eyeDropper.open = async (options?: EyeDropperOpenOptions) => {
+    try {
+      return await originOpen(options);
+    } catch (e) {
+      // 用户取消操作
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return undefined;
+      }
+      throw e;
+    }
+  };
+  return eyeDropper;
+};

--- a/js/color-picker/index.ts
+++ b/js/color-picker/index.ts
@@ -5,3 +5,4 @@ export * from './draggable';
 export * from './format';
 export * from './gradient';
 export * from './types';
+export * from './eyedropper';

--- a/js/color-picker/types.ts
+++ b/js/color-picker/types.ts
@@ -31,3 +31,44 @@ export interface ColorInputProp {
   flex?: number;
   format?: Function;
 }
+
+declare global {
+  interface Window {
+    /**
+     * 浏览器原生取色器（EyeDropper API）
+     *
+     * Chromium 95+ 支持，
+     * Safari、Firefox 目前暂未完全支持。
+     */
+    EyeDropper?: new () => {
+      /**
+       * 打开系统取色器
+       *
+       * @param options 打开配置
+       * @returns 用户选中的颜色结果
+       */
+      open(options?: EyeDropperOpenOptions): Promise<EyeDropperOpenResult>;
+    };
+  }
+}
+
+/**
+ * EyeDropper 返回结果
+ */
+export interface EyeDropperOpenResult {
+  /**
+   * 选中的颜色（sRGB Hex 格式）
+   * 例如：#409EFF
+   */
+  sRGBHex: string;
+}
+
+/**
+ * EyeDropper 打开配置
+ */
+export interface EyeDropperOpenOptions {
+  /**
+   * 用于主动取消取色操作
+   */
+  signal?: AbortSignal;
+}

--- a/style/web/components/color-picker/_index.less
+++ b/style/web/components/color-picker/_index.less
@@ -46,6 +46,7 @@
       background: @bg-color-container-hover;
       transition: @anim-duration-base linear;
     }
+
     &.@{prefix}-is-disabled {
       color: @text-color-disabled;
       pointer-events: none;
@@ -136,12 +137,10 @@
 
 .transparentBgImage () {
   /* stylelint-disable-next-line color-no-hex */
-  background-image:
-    linear-gradient(45deg, #c5c5c5 25%, transparent 0, transparent 75%, #c5c5c5 0, #c5c5c5),
+  background-image: linear-gradient(45deg, #c5c5c5 25%, transparent 0, transparent 75%, #c5c5c5 0, #c5c5c5),
     linear-gradient(45deg, #c5c5c5 25%, transparent 0, transparent 75%, #c5c5c5 0, #c5c5c5);
   background-size: 6px 6px;
-  background-position:
-    0 0,
+  background-position: 0 0,
     3px 3px;
 }
 
@@ -238,6 +237,23 @@
   }
 }
 
+.@{prefix}-color-picker__eyedropper {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: @color-picker-margin;
+  width: @color-picker-gradient-preview-width;
+  height: @color-picker-gradient-preview-height;
+  border-radius: @color-picker-gradient-preview-radius;
+  transition: @anim-duration-base linear;
+  cursor: pointer;
+
+  &:hover {
+    background: @bg-color-container-hover;
+  }
+}
+
 .@{prefix}-color-picker__gradient {
   padding: 0;
   display: flex;
@@ -253,17 +269,15 @@
     flex-shrink: 0;
     margin-left: @color-picker-margin;
     width: @color-picker-degree-width;
+
     .@{prefix}-input {
       margin: 0;
       font: @color-picker-font;
     }
+
     .@{prefix}-input-number {
+      width: 100%;
       padding: 0;
-      &.@{prefix}-size-s,
-      &.@{prefix}-size-m,
-      &.@{prefix}-size-l {
-        width: 100%;
-      }
     }
   }
 
@@ -289,6 +303,7 @@
       &::before {
         display: none;
       }
+
       &.@{prefix}-is-active {
         z-index: 1;
         outline: 2px solid @component-border;
@@ -326,10 +341,12 @@
     &:last-child {
       flex: 1;
     }
+
     .@{prefix}-size-m,
     .@{prefix}-input.@{prefix}-size-m {
       font: @color-picker-font;
     }
+
     .@{prefix}-input-number .@{prefix}-input {
       margin: 0;
     }
@@ -344,6 +361,7 @@
         flex: 1;
         width: 0;
         margin-left: -1px;
+
         .@{prefix}-input {
           padding: 0 1px;
 
@@ -374,6 +392,7 @@
           }
         }
       }
+
       .@{prefix}-input-number {
         width: 100%;
         padding: 0;
@@ -424,6 +443,7 @@
       display: flex;
       align-items: center;
       font-size: 0;
+
       .@{prefix}-color-picker__icon {
         width: @color-picker-swatch-icon-size;
         height: @color-picker-swatch-icon-size;
@@ -518,9 +538,11 @@
   &--default {
     display: inline-flex;
     align-items: center;
+
     > .@{prefix}-input {
       width: fit-content;
     }
+
     .@{prefix}-input {
       padding: @color-picker-trigger-input-padding;
     }
@@ -572,12 +594,14 @@
     opacity: .8;
     cursor: not-allowed;
   }
+
   .@{prefix}-color-picker__gradient-slider {
     .gradient-thumbs,
     .gradient-thumbs__item {
       cursor: not-allowed;
     }
   }
+
   .@{prefix}-color-picker__swatches--item:hover {
     padding: @color-picker-swatch-padding;
   }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他




### 🔗 相关 Issue
#2568 
### 💡 需求背景和解决方案
#### 需求背景
目前 ColorPicker 的吸色能力仅支持组件内部交互，未支持浏览器提供的原生 EyeDropper API。
Chromium 系浏览器（Chrome、Edge 等）已支持 EyeDropper API，可直接从屏幕中拾取任意颜色，能够提供更符合用户预期的吸色体验。为提升 ColorPicker 的易用性和与浏览器能力的一致性，因此为组件增加浏览器原生吸色器支持，并在不支持该 API 的浏览器中保持原有行为，不影响现有功能。

#### 代码逻辑
- 新增 EyeDropper 工具方法，对浏览器原生 EyeDropper API 进行统一封装。
- 补充 TypeScript 类型声明，兼容当前 TypeScript 环境缺少 EyeDropper 类型定义的问题。
- 在支持 EyeDropper API 的浏览器中，调用原生吸色器完成屏幕取色。
- 对用户主动取消取色（AbortError）进行兼容处理，避免产生异常报错。
- 判断当前浏览器是否支持 EyeDropper API ，不影响现有 ColorPicker 的使用体验。

#### 功能演示
https://github.com/user-attachments/assets/933895ef-6059-4342-bbe4-50b03dcf792d


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

feat(color-picker): add native EyeDropper API support

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
