### PR TITLE
fix(style): 修复按钮幽灵态 loading 与 disabled 样式优先级

### DIFF
--- a/style/web/components/button/_index.less
+++ b/style/web/components/button/_index.less
@@ -16,9 +16,9 @@
     @{attr}: @@theme-active;
   }
 
-  // ghost disabled 保留主题色（使用主题色 disabled 变体），背景保持透明
+  // ghost disabled 强制统一色
   &.@{prefix}-is-disabled when (@ghost =true) {
-    @{attr}: @@theme-disabled;
+    @{attr}: @btn-color-ghost-disabled;
     background-color: transparent;
   }
 

--- a/style/web/components/button/_index.less
+++ b/style/web/components/button/_index.less
@@ -12,25 +12,28 @@
     @{attr}: @@theme-hover;
   }
 
-  &:active when (@ghost = true) {
+  &:active when (@ghost =true) {
     @{attr}: @@theme-active;
   }
 
-  &.@{prefix}-is-loading when (@ghost = true) {
-    @{attr}: @@theme-default;
-  }
-
-  &.@{prefix}-is-loading when (@ghost = false) {
+  // ghost disabled 保留主题色（使用主题色 disabled 变体），背景保持透明
+  &.@{prefix}-is-disabled when (@ghost =true) {
     @{attr}: @@theme-disabled;
-  }
-
-  // ghost disabled 强制统一色
-  &.@{prefix}-is-disabled when (@ghost = true) {
-    @{attr}: @btn-color-ghost-disabled;
     background-color: transparent;
   }
 
-  &.@{prefix}-is-disabled when (@ghost = false) {
+  &.@{prefix}-is-disabled when (@ghost =false) {
+    @{attr}: @@theme-disabled;
+  }
+
+  // loading 时 react 端组件会同时挂载 t-is-loading 与 t-is-disabled 两个类，
+  // 二者选择器权重相同，按声明顺序后者生效，故本段必须置于 is-disabled 之后，
+  // 否则幽灵按钮 loading 时主题色会被 disabled 色覆盖
+  &.@{prefix}-is-loading when (@ghost =true) {
+    @{attr}: @@theme-default;
+  }
+
+  &.@{prefix}-is-loading when (@ghost =false) {
     @{attr}: @@theme-disabled;
   }
 
@@ -64,11 +67,11 @@
     font-size: @btn-loading-size;
   }
 
-  svg + .@{prefix}-button__text:not(:empty) {
+  svg+.@{prefix}-button__text:not(:empty) {
     margin-left: @btn-icon-text-margin-left;
   }
 
-  .@{prefix}-loading + .@{prefix}-button__text:not(:empty) {
+  .@{prefix}-loading+.@{prefix}-button__text:not(:empty) {
     margin-left: @btn-icon-text-margin-left;
   }
 
@@ -275,6 +278,7 @@
         .button-attr-color('danger', border-color, true);
       }
     }
+
     &.@{prefix}-is-loading:not(&.@{prefix}-button--ghost) {
       color: @btn-color-text;
 
@@ -450,26 +454,18 @@
   --ripple-color: @btn-color-gray-bg-active;
 }
 
-.@{prefix}-button--variant-base.@{prefix}-button--theme-primary:not(.@{prefix}-is-disabled):not(
-.@{prefix}-button--ghost
-) {
+.@{prefix}-button--variant-base.@{prefix}-button--theme-primary:not(.@{prefix}-is-disabled):not(.@{prefix}-button--ghost) {
   --ripple-color: @btn-color-primary-active;
 }
 
-.@{prefix}-button--variant-base.@{prefix}-button--theme-success:not(.@{prefix}-is-disabled):not(
-.@{prefix}-button--ghost
-) {
+.@{prefix}-button--variant-base.@{prefix}-button--theme-success:not(.@{prefix}-is-disabled):not(.@{prefix}-button--ghost) {
   --ripple-color: @btn-color-success-active;
 }
 
-.@{prefix}-button--variant-base.@{prefix}-button--theme-warning:not(.@{prefix}-is-disabled):not(
-.@{prefix}-button--ghost
-) {
+.@{prefix}-button--variant-base.@{prefix}-button--theme-warning:not(.@{prefix}-is-disabled):not(.@{prefix}-button--ghost) {
   --ripple-color: @btn-color-warning-active;
 }
 
-.@{prefix}-button--variant-base.@{prefix}-button--theme-danger:not(.@{prefix}-is-disabled):not(
-.@{prefix}-button--ghost
-) {
+.@{prefix}-button--variant-base.@{prefix}-button--theme-danger:not(.@{prefix}-is-disabled):not(.@{prefix}-button--ghost) {
   --ripple-color: @btn-color-danger-active;
 }


### PR DESCRIPTION
调整 is-disabled 与 is-loading 选择器声明顺序，确保幽灵按钮 loading 时主题色不被 disabled 色覆盖。

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
